### PR TITLE
add . after 'Cannot be resolved' to make it easy to search for records no

### DIFF
--- a/webconsole/src/main/java/org/apache/felix/webconsole/internal/core/BundlesServlet.java
+++ b/webconsole/src/main/java/org/apache/felix/webconsole/internal/core/BundlesServlet.java
@@ -1224,6 +1224,8 @@ public class BundlesServlet extends SimpleWebConsolePlugin implements OsgiManage
             {
                 val.append( " and overwritten by Boot Delegation" );
             }
+            
+            val.append(".");
         }
 
         if ( marker != null ) {


### PR DESCRIPTION
add . after 'Cannot be resolved' to make it easy to search for records not followed by 'but cannot be resolved'
