### PR TITLE
[FELIX-4584] Change retention to RUNTIME for Property and Properties annotations

### DIFF
--- a/scrplugin/annotations/src/main/java/org/apache/felix/scr/annotations/Properties.java
+++ b/scrplugin/annotations/src/main/java/org/apache/felix/scr/annotations/Properties.java
@@ -24,7 +24,7 @@ import java.lang.annotation.*;
  * Allows to define multiple {@link Property} annotations for one type.
  */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Properties {
 

--- a/scrplugin/annotations/src/main/java/org/apache/felix/scr/annotations/Property.java
+++ b/scrplugin/annotations/src/main/java/org/apache/felix/scr/annotations/Property.java
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
  * OSGi Service Platform Service Compendium Specification for more information.
  */
 @Target( { ElementType.TYPE, ElementType.FIELD })
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Property {
 


### PR DESCRIPTION
This change allows us to access Property annotation values in plain java unit tests. Without this our unit tests would have to run in an SCR-capable container.

You may consider changing the retention for the whole lot (why not), but at least these two are necessary.

https://issues.apache.org/jira/browse/FELIX-4584
