### PR TITLE
Add full path in case of exception when extracting a class from JAR file

### DIFF
--- a/framework/src/main/java/org/apache/felix/framework/cache/JarContent.java
+++ b/framework/src/main/java/org/apache/felix/framework/cache/JarContent.java
@@ -160,7 +160,7 @@ public class JarContent implements Content
         {
             m_logger.log(
                 Logger.LOG_ERROR,
-                "JarContent: Unable to read bytes.", ex);
+                "JarContent: Unable to read bytes for file " + name + " in ZIP file " + m_file.getAbsolutePath(), ex);
             return null;
         }
         finally


### PR DESCRIPTION
When bundles are being redeployed, several versions might be present in the "data/cache" directory.  When a class is attempted to be loaded from a previous version of a bundle which already has been undeployed, an exception occurs which should contain the full path to the file.
