### PR TITLE
Escape pid segment names only when truly necessary

### DIFF
--- a/configadmin/src/test/java/org/apache/felix/cm/file/FilePersistenceManagerTest.java
+++ b/configadmin/src/test/java/org/apache/felix/cm/file/FilePersistenceManagerTest.java
@@ -102,7 +102,7 @@ public class FilePersistenceManagerTest extends TestCase
             assertEquals("%0043ON", winFpm.encodePid( "CON" ));
             assertEquals("%0050RN", winFpm.encodePid( "PRN" ));
             assertEquals("%0041UX", winFpm.encodePid( "AUX" ));
-            assertEquals("%0043LOCK%0024", winFpm.encodePid( "CLOCK$" ));
+            assertEquals("CLOCK%0024", winFpm.encodePid( "CLOCK$" ));
             assertEquals("%004eUL", winFpm.encodePid( "NUL" ));
             assertEquals("%0043OM6", winFpm.encodePid( "COM6" ));
         } finally {


### PR DESCRIPTION
FELIX-4302: Escape only folder names that are truly reserved.

Fixing incompatibility issues that were raised by the solution of FELIX-4302.
