### PR TITLE
FELIX-5137 Added felix.fileinstall.subdir.mode = jar | skip | recurse

### DIFF
--- a/fileinstall/src/main/java/org/apache/felix/fileinstall/internal/DirectoryWatcher.java
+++ b/fileinstall/src/main/java/org/apache/felix/fileinstall/internal/DirectoryWatcher.java
@@ -106,6 +106,7 @@ public class DirectoryWatcher extends Thread implements BundleListener
     public final static String OPTIONAL_SCOPE = "felix.fileinstall.optionalImportRefreshScope";
     public final static String FRAGMENT_SCOPE = "felix.fileinstall.fragmentRefreshScope";
     public final static String DISABLE_NIO2 = "felix.fileinstall.disableNio2";
+    public final static String SUBDIR_MODE = "felix.fileinstall.subdir.mode";
 
     public final static String SCOPE_NONE = "none";
     public final static String SCOPE_MANAGED = "managed";
@@ -185,12 +186,12 @@ public class DirectoryWatcher extends Thread implements BundleListener
         this.context.addBundleListener(this);
 
         if (disableNio2) {
-            scanner = new Scanner(watchedDirectory, filter);
+            scanner = new Scanner(watchedDirectory, filter, properties.get(SUBDIR_MODE));
         } else {
             try {
-                scanner = new WatcherScanner(context, watchedDirectory, filter);
+                scanner = new WatcherScanner(context, watchedDirectory, filter, properties.get(SUBDIR_MODE));
             } catch (Throwable t) {
-                scanner = new Scanner(watchedDirectory, filter);
+                scanner = new Scanner(watchedDirectory, filter, properties.get(SUBDIR_MODE));
             }
         }
     }

--- a/fileinstall/src/main/java/org/apache/felix/fileinstall/internal/FileInstall.java
+++ b/fileinstall/src/main/java/org/apache/felix/fileinstall/internal/FileInstall.java
@@ -104,6 +104,7 @@ public class FileInstall implements BundleActivator, ServiceTrackerCustomizer
             set(ht, DirectoryWatcher.NO_INITIAL_DELAY);
             set(ht, DirectoryWatcher.START_LEVEL);
             set(ht, DirectoryWatcher.OPTIONAL_SCOPE);
+            set(ht, DirectoryWatcher.SUBDIR_MODE);
 
             // check if dir is an array of dirs
             String dirs = ht.get(DirectoryWatcher.DIR);


### PR DESCRIPTION
This PR adds the ability to configure the mode fileinstall operates. the default mode is "jar" which means subdirectories in watched directories are treated as exploded jar.
"skip" just skips subdirectories (for example to install a second watcher in that dir with different update interval)
"recurse" will now pick the config files in any nested directory as if they would be in the watched directory. iThis mode is designed to "organize" config files in subdirectories
