### PR TITLE
FELIX-5203 Remove unused org.apache.felix.http.debug property from http service

### DIFF
--- a/http/jetty/src/main/java/org/apache/felix/http/jetty/internal/ConfigMetaTypeProvider.java
+++ b/http/jetty/src/main/java/org/apache/felix/http/jetty/internal/ConfigMetaTypeProvider.java
@@ -197,12 +197,6 @@ class ConfigMetaTypeProvider implements MetaTypeProvider
                 204800,
                 bundle.getBundleContext().getProperty(JettyConfig.FELIX_JETTY_MAX_FORM_SIZE)));
 
-        adList.add(new AttributeDefinitionImpl(JettyConfig.FELIX_HTTP_DEBUG,
-                "Debug Logging",
-                "Whether to write DEBUG level messages or not. Defaults to false.",
-                false,
-                bundle.getBundleContext().getProperty(JettyConfig.FELIX_HTTP_DEBUG)));
-
         adList.add(new AttributeDefinitionImpl(JettyConfig.FELIX_HTTP_PATH_EXCLUSIONS,
                 "Path Exclusions",
                 "Contains a list of context path prefixes. If a Web Application Bundle is started with a context path matching any " +

--- a/http/jetty/src/main/java/org/apache/felix/http/jetty/internal/JettyConfig.java
+++ b/http/jetty/src/main/java/org/apache/felix/http/jetty/internal/JettyConfig.java
@@ -44,10 +44,6 @@ public final class JettyConfig
     /** Felix specific property to set http reaching timeout limit */
     public static final String HTTP_TIMEOUT = "org.apache.felix.http.timeout";
 
-    /** Felix specific property to enable debug messages */
-    public static final String FELIX_HTTP_DEBUG = "org.apache.felix.http.debug";
-    public static final String HTTP_DEBUG = "org.apache.felix.http.jetty.debug";
-
     /** Felix specific property to override the keystore file location. */
     public static final String FELIX_KEYSTORE = "org.apache.felix.https.keystore";
     private static final String OSCAR_KEYSTORE = "org.ungoverned.osgi.bundle.https.keystore";
@@ -357,11 +353,6 @@ public final class JettyConfig
     public String getTruststoreType()
     {
         return getProperty(FELIX_TRUSTSTORE_TYPE, KeyStore.getDefaultType());
-    }
-
-    public boolean isDebug()
-    {
-        return getBooleanProperty(FELIX_HTTP_DEBUG, getBooleanProperty(HTTP_DEBUG, false));
     }
 
     public boolean isRegisterMBeans()

--- a/httplite/core/src/main/java/org/apache/felix/httplite/osgi/Activator.java
+++ b/httplite/core/src/main/java/org/apache/felix/httplite/osgi/Activator.java
@@ -118,8 +118,6 @@ public class Activator implements BundleActivator
             context.getProperty(Server.CONFIG_PROPERTY_HTTP_ENABLE));
         config.put(Server.CONFIG_PROPERTY_HTTPS_ENABLE,
             context.getProperty(Server.CONFIG_PROPERTY_HTTPS_ENABLE));
-        config.put(Server.CONFIG_PROPERTY_HTTP_DEBUG,
-            context.getProperty(Server.CONFIG_PROPERTY_HTTP_DEBUG));
         config.put(Server.CONFIG_PROPERTY_THREADPOOL_LIMIT_PROP,
             context.getProperty(Server.CONFIG_PROPERTY_THREADPOOL_LIMIT_PROP));
         config.put(Server.CONFIG_PROPERTY_THREADPOOL_TIMEOUT_PROP,

--- a/httplite/core/src/main/java/org/apache/felix/httplite/server/Server.java
+++ b/httplite/core/src/main/java/org/apache/felix/httplite/server/Server.java
@@ -53,10 +53,6 @@ public class Server
      * Thread pool limit property
      */
     public static final String CONFIG_PROPERTY_THREADPOOL_LIMIT_PROP = "org.apache.felix.http.threadpool.limit";
-     /**
-     * Flag to enable debugging for this service implementation. The default is false.
-     */
-    public static final String CONFIG_PROPERTY_HTTP_DEBUG = "org.apache.felix.http.debug";
     /**
      * Flag to enable the user of HTTPS. The default is false.
      */


### PR DESCRIPTION
The `org.apache.felix.http.jetty` bundle has a "Debug Logging" boolean property (`org.apache.felix.http.debug`) which is unused. This property is only used by the internal JettyConfig.isDebug method, which is in turn is unused.

Jetty debug logging is now handed by filtering the logger category.

See:
http://www.mail-archive.com/users%40felix.apache.org/msg17122.html
