### PR TITLE
[FELIX-5217] fileinstall: Improve WatcherScanner performance

### DIFF
--- a/fileinstall/src/main/java/org/apache/felix/fileinstall/internal/WatcherScanner.java
+++ b/fileinstall/src/main/java/org/apache/felix/fileinstall/internal/WatcherScanner.java
@@ -97,7 +97,7 @@ public class WatcherScanner extends Scanner {
             }
             for (File file : removed) {
                 // Make sure we'll handle a file that has been deleted
-                files.addAll(removed);
+                files.add(file);
                 // Remove no longer used checksums
                 lastChecksums.remove(file);
                 storedChecksums.remove(file);


### PR DESCRIPTION
note that the other option is to call addAll before the loop, but because the return value is ignored anyway, it is slightly more efficient to do this in the loop.
