### PR TITLE
[FELIX-5218] fileinstall: Removed files should no longer be considere…

### DIFF
--- a/fileinstall/src/main/java/org/apache/felix/fileinstall/internal/WatcherScanner.java
+++ b/fileinstall/src/main/java/org/apache/felix/fileinstall/internal/WatcherScanner.java
@@ -101,6 +101,7 @@ public class WatcherScanner extends Scanner {
                 // Remove no longer used checksums
                 lastChecksums.remove(file);
                 storedChecksums.remove(file);
+                changed.remove(file);
             }
 
             return files;


### PR DESCRIPTION
…d changed.

This is probably a regression from adding the stable checksum mechanism. All removed files need to be removed from the "changed" hash set, otherwise they would be seen next iteration again and again be considered as removed.
