### PR TITLE
DTO Sourcing

### DIFF
--- a/converter/converter/src/main/java/org/apache/felix/converter/impl/ConvertingImpl.java
+++ b/converter/converter/src/main/java/org/apache/felix/converter/impl/ConvertingImpl.java
@@ -189,7 +189,7 @@ public class ConvertingImpl implements Converting, InternalConverting {
             return convertToArray();
         } else if (Collection.class.isAssignableFrom(targetAsClass)) {
             return convertToCollection();
-        } else if (isDTOType(targetAsClass) || (DTO.class.equals(sourceClass) && DTO.class.isAssignableFrom(targetActualClass))) {
+        } else if (isDTOType(targetAsClass) || ((DTO.class.equals(sourceClass) || DTO.class.equals(targetAsClass)) && DTO.class.isAssignableFrom(targetActualClass))) {
             return convertToDTO();
         } else if (isMapType(targetAsClass)) {
             return convertToMapType();
@@ -279,16 +279,19 @@ public class ConvertingImpl implements Converting, InternalConverting {
     private <T> T convertToDTO() {
         Map m = mapView(object, sourceClass, converter);
 
+        Class<?> cls = targetAsClass;
+        if (DTO.class.equals(targetAsClass))
+            cls = targetActualClass;
         try {
             T dto = (T) targetActualClass.newInstance();
 
             for (Map.Entry entry : (Set<Map.Entry>) m.entrySet()) {
                 Field f = null;
                 try {
-                    f = targetAsClass.getDeclaredField(mangleName(entry.getKey().toString()));
+                    f = cls.getDeclaredField(mangleName(entry.getKey().toString()));
                 } catch (NoSuchFieldException e) {
                     try {
-                        f = targetAsClass.getField(mangleName(entry.getKey().toString()));
+                        f = cls.getField(mangleName(entry.getKey().toString()));
                     } catch (NoSuchFieldException e1) {
                         // There is not field with this name
                     }

--- a/converter/converter/src/main/java/org/apache/felix/converter/impl/ConvertingImpl.java
+++ b/converter/converter/src/main/java/org/apache/felix/converter/impl/ConvertingImpl.java
@@ -774,6 +774,9 @@ public class ConvertingImpl implements Converting, InternalConverting {
             Object fVal = field.get(obj);
             if (isMapType(field.getType())) {
                 fVal = converter.convert(fVal).key(ka).to(Map.class);
+             // Depends on whether or not a copy to Map is supposed to be a "deep" copy 
+//            } else if (fVal instanceof DTO) {
+//                fVal = converter.convert(fVal).sourceAs(DTO.class).to(Map.class);
             }
 
             result.put(fn, fVal);
@@ -843,7 +846,7 @@ public class ConvertingImpl implements Converting, InternalConverting {
     }
 
     private Map<?,?> mapView(Object obj, Class<?> sourceCls, InternalConverter converter) {
-        if (Map.class.isAssignableFrom(sourceCls))
+        if (Map.class.isAssignableFrom(sourceCls) || (DTO.class.equals(sourceCls) && obj instanceof Map))
             return (Map<?,?>) obj;
         else if (Dictionary.class.isAssignableFrom(sourceCls))
             return null; // TODO

--- a/converter/converter/src/main/java/org/apache/felix/converter/impl/ConvertingImpl.java
+++ b/converter/converter/src/main/java/org/apache/felix/converter/impl/ConvertingImpl.java
@@ -448,9 +448,6 @@ public class ConvertingImpl implements Converting, InternalConverting {
     }
 
     private static boolean isDTOType(Class<?> cls) {
-        if (DTO.class.equals(cls))
-            return true;
-
         try {
             cls.getDeclaredConstructor();
         } catch (NoSuchMethodException | SecurityException e) {
@@ -840,7 +837,7 @@ public class ConvertingImpl implements Converting, InternalConverting {
             return (Map<?,?>) obj;
         else if (Dictionary.class.isAssignableFrom(sourceCls))
             return null; // TODO
-        else if (isDTOType(sourceCls))
+        else if (isDTOType(sourceCls) || DTO.class.equals(sourceCls))
             return createMapFromDTO(obj, converter);
         else {
             if (sourceAsJavaBean) {

--- a/converter/converter/src/main/java/org/apache/felix/converter/impl/ConvertingImpl.java
+++ b/converter/converter/src/main/java/org/apache/felix/converter/impl/ConvertingImpl.java
@@ -846,7 +846,7 @@ public class ConvertingImpl implements Converting, InternalConverting {
     }
 
     private Map<?,?> mapView(Object obj, Class<?> sourceCls, InternalConverter converter) {
-        if (Map.class.isAssignableFrom(sourceCls) || (DTO.class.equals(sourceCls) && obj instanceof Map))
+        if (Map.class.isAssignableFrom(sourceCls) || (DTO.class.isAssignableFrom(sourceCls) && obj instanceof Map))
             return (Map<?,?>) obj;
         else if (Dictionary.class.isAssignableFrom(sourceCls))
             return null; // TODO

--- a/converter/converter/src/main/java/org/apache/felix/converter/impl/ConvertingImpl.java
+++ b/converter/converter/src/main/java/org/apache/felix/converter/impl/ConvertingImpl.java
@@ -448,6 +448,9 @@ public class ConvertingImpl implements Converting, InternalConverting {
     }
 
     private static boolean isDTOType(Class<?> cls) {
+        if (DTO.class.equals(cls))
+            return true;
+
         try {
             cls.getDeclaredConstructor();
         } catch (NoSuchMethodException | SecurityException e) {

--- a/converter/converter/src/main/java/org/apache/felix/converter/impl/ConvertingImpl.java
+++ b/converter/converter/src/main/java/org/apache/felix/converter/impl/ConvertingImpl.java
@@ -189,7 +189,7 @@ public class ConvertingImpl implements Converting, InternalConverting {
             return convertToArray();
         } else if (Collection.class.isAssignableFrom(targetAsClass)) {
             return convertToCollection();
-        } else if (isDTOType(targetAsClass)) {
+        } else if (isDTOType(targetAsClass) || (DTO.class.equals(sourceClass) && DTO.class.isAssignableFrom(targetActualClass))) {
             return convertToDTO();
         } else if (isMapType(targetAsClass)) {
             return convertToMapType();
@@ -296,7 +296,11 @@ public class ConvertingImpl implements Converting, InternalConverting {
 
                 if (f != null) {
                     Object val = entry.getValue();
-                    f.set(dto, converter.convert(val).to(f.getType()));
+                    if (DTO.class.equals(sourceClass) && DTO.class.isAssignableFrom(f.getType()))
+                        val = converter.convert(val).sourceAs(DTO.class).to(f.getType());
+                    else
+                        val = converter.convert(val).to(f.getType());
+                    f.set(dto, val);
                 }
             }
 
@@ -342,7 +346,10 @@ public class ConvertingImpl implements Converting, InternalConverting {
                     if (isCopyRequiredType(cls)) {
                         cls = getConstructableType(cls);
                     }
-                    value = converter.convert(value).key(ka).to(cls);
+                    if (DTO.class.equals(sourceAsClass) && DTO.class.isAssignableFrom(cls))
+                        value = converter.convert(value).key(ka).sourceAs(sourceAsClass).to(cls);
+                    else
+                        value = converter.convert(value).key(ka).to(cls);
                 }
             }
             instance.put(key, value);
@@ -850,6 +857,8 @@ public class ConvertingImpl implements Converting, InternalConverting {
     }
 
     private static boolean isCopyRequiredType(Class<?> cls) {
+        if (cls.isEnum())
+            return false;
         return Map.class.isAssignableFrom(cls) ||
                 Collection.class.isAssignableFrom(cls) ||
                 DTO.class.isAssignableFrom(cls) ||

--- a/converter/converter/src/test/java/org/apache/felix/converter/impl/ConverterTest.java
+++ b/converter/converter/src/test/java/org/apache/felix/converter/impl/ConverterTest.java
@@ -463,6 +463,33 @@ public class ConverterTest {
         assertEquals(Alpha.A, e.get("alpha"));
     }
 
+    @Test
+    public void testDTO2Map2() {
+        MyEmbeddedDTO embedded = new MyEmbeddedDTO();
+        embedded.marco = "hohoho";
+        embedded.polo = Long.MAX_VALUE;
+        embedded.alpha = Alpha.A;
+
+        MyDTO dto = new MyDTO();
+        dto.ping = "lalala";
+        dto.pong = Long.MIN_VALUE;
+        dto.count = Count.ONE;
+        dto.embedded = embedded;
+
+        @SuppressWarnings("rawtypes")
+        Map m = converter.convert(dto).sourceAs(DTO.class).to(Map.class);
+        assertEquals(4, m.size());
+        assertEquals("lalala", m.get("ping"));
+        assertEquals(Long.MIN_VALUE, m.get("pong"));
+        assertEquals(Count.ONE, m.get("count"));
+        assertNotNull(m.get("embedded"));
+        @SuppressWarnings("rawtypes")
+        Map e = (Map)m.get("embedded");
+        assertEquals("hohoho", e.get("marco"));
+        assertEquals(Long.MAX_VALUE, e.get("polo"));
+        assertEquals(Alpha.A, e.get("alpha"));
+    }
+
     @Test @SuppressWarnings({ "rawtypes", "unchecked" })
     public void testDTOFieldShadowing() {
         MySubDTO dto = new MySubDTO();

--- a/converter/converter/src/test/java/org/apache/felix/converter/impl/ConverterTest.java
+++ b/converter/converter/src/test/java/org/apache/felix/converter/impl/ConverterTest.java
@@ -52,6 +52,7 @@ import org.apache.felix.converter.impl.MyEmbeddedDTO.Alpha;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.osgi.dto.DTO;
 import org.osgi.util.converter.ConversionException;
 import org.osgi.util.converter.Converter;
 import org.osgi.util.converter.ConverterBuilder;
@@ -603,7 +604,7 @@ public class ConverterTest {
     }
 
     @Test
-    public void testConvertAs1() {
+    public void testConvertAsInterface() {
         MyBean mb = new MyBean();
         mb.intfVal = 17;
         mb.beanVal = "Hello";
@@ -613,13 +614,21 @@ public class ConverterTest {
     }
 
     @Test
-    public void testConvertAs2() {
+    public void testConvertAsBean() {
         MyBean mb = new MyBean();
         mb.intfVal = 17;
         mb.beanVal = "Hello";
 
         assertEquals(Collections.singletonMap("value", "Hello"),
                 converter.convert(mb).sourceAsBean().to(Map.class));
+    }
+
+    @Test
+    public void testConvertAsDTO() {
+        MyClass3 mc3 = new MyClass3(17);
+
+        assertEquals(17,
+                converter.convert(mc3).sourceAs(DTO.class).to(Map.class).get("value"));
     }
 
     @Test
@@ -678,6 +687,19 @@ public class ConverterTest {
 
         public String getValue() {
             return beanVal;
+        }
+    }
+
+    static class MyClass3 {
+        public int value;
+        public String string = "String";
+
+        public MyClass3( int value ) {
+            this.value = value;
+        }
+
+        public int value() {
+            return value;
         }
     }
 }

--- a/converter/converter/src/test/java/org/apache/felix/converter/impl/ConverterTest.java
+++ b/converter/converter/src/test/java/org/apache/felix/converter/impl/ConverterTest.java
@@ -490,6 +490,45 @@ public class ConverterTest {
         assertEquals(Alpha.A, e.get("alpha"));
     }
 
+    @Test
+    public void testDTO2Map3() {
+        MyEmbeddedDTO embedded2 = new MyEmbeddedDTO();
+        embedded2.marco = "hohoho";
+        embedded2.polo = Long.MAX_VALUE;
+        embedded2.alpha = Alpha.A;
+
+        MyDTOWithMethods embedded = new MyDTOWithMethods();
+        embedded.ping = "lalala";
+        embedded.pong = Long.MIN_VALUE;
+        embedded.count = Count.ONE;
+        embedded.embedded = embedded2;
+
+        MyDTO8 dto = new MyDTO8();
+        dto.ping = "lalala";
+        dto.pong = Long.MIN_VALUE;
+        dto.count = MyDTO8.Count.ONE;
+        dto.embedded = embedded;
+
+        @SuppressWarnings("rawtypes")
+        Map m = converter.convert(dto).sourceAs(DTO.class).to(Map.class);
+        assertEquals(4, m.size());
+        assertEquals("lalala", m.get("ping"));
+        assertEquals(Long.MIN_VALUE, m.get("pong"));
+        assertEquals(MyDTO8.Count.ONE, m.get("count"));
+        assertNotNull(m.get("embedded"));
+        assertTrue(m.get( "embedded" ) instanceof MyDTOWithMethods);
+        MyDTOWithMethods e = (MyDTOWithMethods)m.get("embedded");
+        assertEquals("lalala", e.ping);
+        assertEquals(Long.MIN_VALUE, e.pong);
+        assertEquals(Count.ONE, e.count);
+        assertNotNull(e.embedded);
+        assertTrue(e.embedded instanceof MyEmbeddedDTO);
+        MyEmbeddedDTO e2 = (MyEmbeddedDTO)e.embedded;
+        assertEquals("hohoho", e2.marco);
+        assertEquals(Long.MAX_VALUE, e2.polo);
+        assertEquals(Alpha.A, e2.alpha);
+    }
+
     @Test @SuppressWarnings({ "rawtypes", "unchecked" })
     public void testDTOFieldShadowing() {
         MySubDTO dto = new MySubDTO();

--- a/converter/converter/src/test/java/org/apache/felix/converter/impl/MyDTO8.java
+++ b/converter/converter/src/test/java/org/apache/felix/converter/impl/MyDTO8.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.felix.converter.impl;
+
+import org.osgi.dto.DTO;
+
+public class MyDTO8 extends DTO {
+    public enum Count { ONE, TWO, THREE }
+
+    public Count count;
+
+    public String ping;
+
+    public long pong;
+
+    public MyDTOWithMethods embedded;
+}
+

--- a/converter/schematizer/pom.xml
+++ b/converter/schematizer/pom.xml
@@ -66,9 +66,9 @@
                 <configuration>
                     <instructions>
                         <Bundle-Activator>org.apache.felix.schematizer.impl.Activator</Bundle-Activator>
-                        <Private-Package>org.apache.felix.schematizer.*, org.apache.felix.serializer.*</Private-Package>
+                        <Private-Package>org.apache.felix.schematizer.*, org.apache.felix.serializer.*, org.yaml.snakeyaml.*</Private-Package>
                         <Export-Package>org.apache.felix.schematizer</Export-Package>
-                        <Import-Package>org.apache.felix.converter, org.apache.felix.serializer, *</Import-Package>
+                        <Import-Package>org.osgi.util.converter, org.osgi.service.serializer, *</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/Node.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/Node.java
@@ -39,6 +39,7 @@ public interface Node {
         public String name;
         public String path;
         public String type;
+        public String collectionType;
         public boolean isCollection;
         public Map<String, Node.DTO> children = new HashMap<>();
     }

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/Node.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/Node.java
@@ -19,6 +19,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.HashMap;
@@ -50,6 +51,7 @@ public interface Node {
      */
     String absolutePath();
     Type type();
+    Field field();
     Optional<TypeReference<?>> typeReference();
     boolean isCollection();
     Map<String, Node> children();

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/Schema.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/Schema.java
@@ -15,6 +15,7 @@
  */
 package org.apache.felix.schematizer;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 
@@ -28,4 +29,6 @@ public interface Schema {
      * Recursively visits all nodes in the {@code Schema} for processing.
      */
     void visit(NodeVisitor visitor);
+
+    Collection<?> valuesAt(String path, Object object);
 }

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/Schema.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/Schema.java
@@ -23,6 +23,7 @@ public interface Schema {
     String name();
     Node rootNode();
     Optional<Node> nodeAtPath(String absolutePath);
+    Optional<Node> parentOf(Node aNode);
     Map<String, Node.DTO> toMap();
 
     /**

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/Schematizer.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/Schematizer.java
@@ -35,4 +35,6 @@ public interface Schematizer {
      * Shortcut for rule(String name, String path, TypeReference<T> type) when path is "/".
      */
     <T extends DTO>Schematizer rule(String name, TypeReference<T> type);
+
+    Schematizer usingLookup(ClassLoader classLoader);    
 }

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/Schematizing.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/Schematizing.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.felix.schematizer;
+
+import org.osgi.util.converter.Converter;
+
+public interface Schematizing {
+    Converter withSchema(Schema s);
+    Schema getSchema();
+}

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/Schematizing.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/Schematizing.java
@@ -19,6 +19,8 @@ package org.apache.felix.schematizer;
 import org.osgi.util.converter.Converter;
 
 public interface Schematizing {
+    Converter asDTO();
+    boolean isDTOType();
     Converter withSchema(Schema s);
     Schema getSchema();
 }

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/SchematizingConverter.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/SchematizingConverter.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.felix.schematizer;
+
+import org.apache.felix.schematizer.impl.SchematizingConverterImpl;
+import org.osgi.util.converter.Converter;
+import org.osgi.util.converter.ConverterBuilder;
+import org.osgi.util.converter.Converting;
+import org.osgi.util.converter.StandardConverter;
+
+public class SchematizingConverter implements Schematizing, Converter {
+    private final SchematizingConverterImpl converter;
+
+    public SchematizingConverter() {
+        converter = new SchematizingConverterImpl(new StandardConverter());
+    }
+
+    public SchematizingConverter(Converter c) {
+        converter = new SchematizingConverterImpl(c);
+    }
+
+    @Override
+    public Converting convert(Object obj) {
+        return converter.convert(obj);
+    }
+
+    @Override
+    public ConverterBuilder newConverterBuilder() {
+        return converter.newConverterBuilder();
+    }
+
+    public Converter withSchema(Schema s) {
+        return converter.withSchema(s);
+    }
+
+    public Schema getSchema() {
+        return converter.getSchema();
+    }
+}

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/SchematizingConverter.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/SchematizingConverter.java
@@ -43,6 +43,17 @@ public class SchematizingConverter implements Schematizing, Converter {
         return converter.newConverterBuilder();
     }
 
+    @Override
+    public Converter asDTO() {
+        converter.asDTO();
+        return converter;
+    }
+
+    @Override
+    public boolean isDTOType() {
+        return converter.isDTOType();
+    }
+
     public Converter withSchema(Schema s) {
         return converter.withSchema(s);
     }

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/StandardSchematizer.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/StandardSchematizer.java
@@ -58,4 +58,9 @@ public class StandardSchematizer implements Schematizer {
     public <T extends DTO> Schematizer rule(String name, TypeReference<T> type) {
         return schematizer.rule(name, type);
     }
+
+    @Override
+    public Schematizer usingLookup(ClassLoader classLoader) {
+        return schematizer.usingLookup(classLoader);
+    }
 }

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/StandardSchematizer.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/StandardSchematizer.java
@@ -19,6 +19,7 @@ package org.apache.felix.schematizer;
 import java.util.Map;
 import java.util.Optional;
 
+import org.apache.felix.schematizer.impl.SchematizerImpl;
 import org.osgi.dto.DTO;
 import org.osgi.util.converter.TypeReference;
 
@@ -26,7 +27,7 @@ public class StandardSchematizer implements Schematizer {
     private final Schematizer schematizer;
 
     public StandardSchematizer() {
-        schematizer = null;//new SchematizerImpl();
+        schematizer = new SchematizerImpl();
     }
 
     @Override

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/CollectionNode.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/CollectionNode.java
@@ -17,7 +17,10 @@ package org.apache.felix.schematizer.impl;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
 
+import org.apache.felix.schematizer.Node;
 import org.osgi.util.converter.TypeReference;
 
 public class CollectionNode
@@ -43,8 +46,25 @@ public class CollectionNode
         collectionType = aCollectionType;
     }
 
+    public CollectionNode(
+            Node.DTO dto, 
+            String contextPath, 
+            Function<String, Type> f, 
+            Map<String, NodeImpl> nodes,
+            Class<? extends Collection<?>> aCollectionType ) {
+        super(dto, contextPath, f, nodes);
+        collectionType = aCollectionType;
+    }
+
     @Override
     public Class<? extends Collection<?>> collectionType() {
         return collectionType;
+    }
+
+    @Override
+    public DTO toDTO() {
+        DTO dto = super.toDTO();
+        dto.collectionType = collectionType.getName();
+        return dto;
     }
 }

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/NodeImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/NodeImpl.java
@@ -57,16 +57,25 @@ public class NodeImpl implements Node {
         absolutePath = anAbsolutePath;
     }
 
+    @SuppressWarnings( { "unchecked", "rawtypes" } )
     public NodeImpl(Node.DTO dto, String contextPath, Function<String, Type> f, Map<String, NodeImpl> nodes) {
         name = dto.name;
         type = f.apply(dto.type);
         isCollection = dto.isCollection;
         absolutePath = contextPath + dto.path;
-        dto.children.values().stream().forEach( c -> {
-                NodeImpl node = new NodeImpl(c, contextPath, f, nodes);
-                children.put("/" + c.name, node);
-                nodes.put(c.path, node);
-            });
+        for (Node.DTO child : dto.children.values()) {
+            NodeImpl node;
+            if (child.isCollection)
+                try {
+                    node = new CollectionNode(child, contextPath, f, nodes, (Class)getClass().getClassLoader().loadClass(child.collectionType));
+                } catch ( ClassNotFoundException e ) {
+                    node = new CollectionNode(child, contextPath, f, nodes, (Class)Collection.class);
+                }
+            else
+                node = new NodeImpl(child, contextPath, f, nodes);
+            children.put("/" + child.name, node);
+            nodes.put(child.path, node);        
+        }
     }
 
     @Override

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/NodeImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/NodeImpl.java
@@ -15,6 +15,7 @@
  */
 package org.apache.felix.schematizer.impl;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.HashMap;
@@ -34,6 +35,7 @@ public class NodeImpl implements Node {
 
     private NodeImpl parent;
     private HashMap<String, NodeImpl> children = new HashMap<>();
+    private Field field;
 
     public NodeImpl(
             String aName,
@@ -105,6 +107,15 @@ public class NodeImpl implements Node {
     @Override
     public String absolutePath() {
         return absolutePath;
+    }
+
+    @Override
+    public Field field() {
+        return field;
+    }
+
+    public void field(Field aField) {
+        field = aField;
     }
 
     @SuppressWarnings( { "unchecked", "rawtypes" } )

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchemaImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchemaImpl.java
@@ -30,7 +30,6 @@ import org.apache.felix.schematizer.Node;
 import org.apache.felix.schematizer.Node.DTO;
 import org.apache.felix.schematizer.NodeVisitor;
 import org.apache.felix.schematizer.Schema;
-import org.apache.felix.schematizer.SchematizingConverter;
 import org.osgi.util.converter.Converter;
 import org.osgi.util.converter.StandardConverter;
 
@@ -59,9 +58,20 @@ public class SchemaImpl
     }
 
     @Override
-    public Optional<Node> nodeAtPath( String absolutePath )
-    {
+    public Optional<Node> nodeAtPath( String absolutePath ) {
         return Optional.ofNullable(nodes.get(absolutePath));
+    }
+
+    @Override
+    public Optional<Node> parentOf( Node aNode ) {
+        if (aNode == null || aNode.absolutePath() == null)
+            return Optional.empty();
+
+        NodeImpl node = nodes.get(aNode.absolutePath());
+        if (node == null)
+            return Optional.empty();
+
+        return Optional.ofNullable( node.parent() );
     }
 
     void add(NodeImpl node) {
@@ -109,6 +119,7 @@ public class SchemaImpl
         return valuesAt("", map, contexts, 0);
     }
 
+    @SuppressWarnings( { "rawtypes", "unchecked" } )
     private Collection<?> valuesAt(String context, Map<String, Object> objectMap, List<String> contexts, int currentIndex) {
         List<Object> result = new ArrayList<>();
         String currentContext = contexts.get(currentIndex);
@@ -140,12 +151,13 @@ public class SchemaImpl
         return result;
     }
 
+    @SuppressWarnings( "rawtypes" )
     private Object convertToType( String path, Map map ) {
         Optional<Node> node = nodeAtPath(path);
         if (!node.isPresent())
             return map;
 
-        Object result = new StandardConverter().convert(map).sourceAs(DTO.class).to(node.get().type());
+        Object result = new StandardConverter().convert(map).to(node.get().type());
         return result;
     }
 

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchemaImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchemaImpl.java
@@ -104,7 +104,7 @@ public class SchemaImpl
     public Collection<?> valuesAt(String path, Object object) {
         final Converter converter = new StandardConverter();
         @SuppressWarnings( "unchecked" )
-        final Map<String, Object> map = (Map<String, Object>)converter.convert( object ).to( Map.class );
+        final Map<String, Object> map = (Map<String, Object>)converter.convert(object).sourceAs(DTO.class).to( Map.class );
         if (map == null || map.isEmpty())
             return Collections.emptyList();
 
@@ -125,7 +125,6 @@ public class SchemaImpl
         String currentContext = contexts.get(currentIndex);
         Object o = objectMap.get(currentContext);
         if (o instanceof List) {
-            @SuppressWarnings( "unchecked" )
             List<Object> l = (List<Object>)o;
             if (currentIndex == contexts.size() - 1) {
                 // We are at the end, so just add the collection
@@ -143,7 +142,7 @@ public class SchemaImpl
                 return result;
             }
 
-            result.addAll( valuesAt( currentContext, (Map)o, contexts, ++currentIndex ) );
+            result.addAll(valuesAt( currentContext, (Map)o, contexts, ++currentIndex));
         } else {
             result.add(o);
         }
@@ -157,7 +156,7 @@ public class SchemaImpl
         if (!node.isPresent())
             return map;
 
-        Object result = new StandardConverter().convert(map).to(node.get().type());
+        Object result = new StandardConverter().convert(map).targetAs(DTO.class).to(node.get().type());
         return result;
     }
 

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchemaImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchemaImpl.java
@@ -24,12 +24,14 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.apache.felix.schematizer.Node;
-import org.apache.felix.schematizer.Node.DTO;
 import org.apache.felix.schematizer.NodeVisitor;
 import org.apache.felix.schematizer.Schema;
+import org.osgi.dto.DTO;
 import org.osgi.util.converter.Converter;
 import org.osgi.util.converter.StandardConverter;
 
@@ -132,7 +134,7 @@ public class SchemaImpl
                 return result;
             }
 
-            currentContext = "/" + contexts.get(++currentIndex);
+            currentContext = pathFrom(contexts, ++currentIndex);
             for (Object o2 : l)
                 result.addAll(valuesAt(currentContext, o2));
         } else if (o instanceof Map){
@@ -143,6 +145,8 @@ public class SchemaImpl
             }
 
             result.addAll(valuesAt( currentContext, (Map)o, contexts, ++currentIndex));
+        } else if (currentIndex < contexts.size() - 1) {
+            result.addAll(valuesAt(pathFrom(contexts, ++currentIndex), o));
         } else {
             result.add(o);
         }
@@ -168,5 +172,13 @@ public class SchemaImpl
         return list.stream()
                 .map( v -> new StandardConverter().convert(v).sourceAs(DTO.class).to(node.get().type()))
                 .collect( Collectors.toList() );
+    }
+
+    private String pathFrom(List<String> contexts, int index) {
+        return IntStream.range(0, contexts.size())
+                .filter( i -> i >= index )
+                .mapToObj( i -> contexts.get(i) )
+                .reduce( "", (s1,s2) -> s1 + "/" + s2 );
+                
     }
 }

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchemaImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchemaImpl.java
@@ -24,10 +24,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.felix.schematizer.Node;
+import org.apache.felix.schematizer.Node.DTO;
 import org.apache.felix.schematizer.NodeVisitor;
 import org.apache.felix.schematizer.Schema;
+import org.apache.felix.schematizer.SchematizingConverter;
 import org.osgi.util.converter.Converter;
 import org.osgi.util.converter.StandardConverter;
 
@@ -102,31 +105,57 @@ public class SchemaImpl
             return Collections.emptyList();
 
         List<String> contexts = Arrays.asList(pathParts);
-        List<Object> values = new ArrayList<>();
 
-        return valuesAt("", map, contexts, 0, values);
+        return valuesAt("", map, contexts, 0);
     }
 
-    private Collection<?> valuesAt(String context, Map<String, Object> objectMap, List<String> contexts, int currentIndex, List<Object> values) {
+    private Collection<?> valuesAt(String context, Map<String, Object> objectMap, List<String> contexts, int currentIndex) {
         List<Object> result = new ArrayList<>();
-        String currentContext = context + contexts.get(currentIndex);
+        String currentContext = contexts.get(currentIndex);
         Object o = objectMap.get(currentContext);
         if (o instanceof List) {
             @SuppressWarnings( "unchecked" )
             List<Object> l = (List<Object>)o;
             if (currentIndex == contexts.size() - 1) {
                 // We are at the end, so just add the collection
-                result.add(l);
+                result.add(convertToType("/" + currentContext, l));
                 return result;
             }
 
             currentContext = "/" + contexts.get(++currentIndex);
             for (Object o2 : l)
                 result.addAll(valuesAt(currentContext, o2));
+        } else if (o instanceof Map){
+            if (currentIndex == contexts.size() - 1) {
+                // We are at the end, so just add the result
+                result.add(convertToType("/" + currentContext, (Map)o));
+                return result;
+            }
+
+            result.addAll( valuesAt( currentContext, (Map)o, contexts, ++currentIndex ) );
         } else {
-            result.add( o );
+            result.add(o);
         }
 
         return result;
+    }
+
+    private Object convertToType( String path, Map map ) {
+        Optional<Node> node = nodeAtPath(path);
+        if (!node.isPresent())
+            return map;
+
+        Object result = new StandardConverter().convert(map).sourceAs(DTO.class).to(node.get().type());
+        return result;
+    }
+
+    private List<?> convertToType( String path, List<?> list ) {
+        Optional<Node> node = nodeAtPath(path);
+        if (!node.isPresent())
+            return list;
+
+        return list.stream()
+                .map( v -> new StandardConverter().convert(v).sourceAs(DTO.class).to(node.get().type()))
+                .collect( Collectors.toList() );
     }
 }

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchemaImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchemaImpl.java
@@ -125,28 +125,37 @@ public class SchemaImpl
     private Collection<?> valuesAt(String context, Map<String, Object> objectMap, List<String> contexts, int currentIndex) {
         List<Object> result = new ArrayList<>();
         String currentContext = contexts.get(currentIndex);
+        if (objectMap == null)
+            return result;
         Object o = objectMap.get(currentContext);
         if (o instanceof List) {
             List<Object> l = (List<Object>)o;
             if (currentIndex == contexts.size() - 1) {
                 // We are at the end, so just add the collection
-                result.add(convertToType("/" + currentContext, l));
+                result.add(convertToType(pathFrom(contexts, 0), l));
                 return result;
             }
 
             currentContext = pathFrom(contexts, ++currentIndex);
             for (Object o2 : l)
-                result.addAll(valuesAt(currentContext, o2));
+            {
+                final Converter converter = new StandardConverter();
+                final Map<String, Object> m = (Map<String, Object>)converter.convert(o2).sourceAs(DTO.class).to( Map.class );
+                result.addAll( valuesAt( currentContext, m, contexts, currentIndex ) );
+            }        
         } else if (o instanceof Map){
             if (currentIndex == contexts.size() - 1) {
                 // We are at the end, so just add the result
-                result.add(convertToType("/" + currentContext, (Map)o));
+                result.add(convertToType(pathFrom(contexts, 0), (Map)o));
                 return result;
             }
 
             result.addAll(valuesAt( currentContext, (Map)o, contexts, ++currentIndex));
         } else if (currentIndex < contexts.size() - 1) {
-            result.addAll(valuesAt(pathFrom(contexts, ++currentIndex), o));
+            final Converter converter = new StandardConverter();
+            final Map<String, Object> m = (Map<String, Object>)converter.convert(o).sourceAs(DTO.class).to(Map.class);
+            currentContext = pathFrom(contexts, ++currentIndex);
+            result.addAll(valuesAt( currentContext, m, contexts, currentIndex ));
         } else {
             result.add(o);
         }

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchemaImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchemaImpl.java
@@ -15,14 +15,21 @@
  */
 package org.apache.felix.schematizer.impl;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import org.apache.felix.schematizer.Node;
 import org.apache.felix.schematizer.NodeVisitor;
 import org.apache.felix.schematizer.Schema;
+import org.osgi.util.converter.Converter;
+import org.osgi.util.converter.StandardConverter;
 
 public class SchemaImpl
         implements Schema
@@ -78,5 +85,50 @@ public class SchemaImpl
     @Override
     public void visit(NodeVisitor visitor) {
         nodes.values().stream().forEach(n ->  visitor.apply(n));
+    }
+
+    @Override
+    public Collection<?> valuesAt(String path, Object object) {
+        final Converter converter = new StandardConverter();
+        @SuppressWarnings( "unchecked" )
+        final Map<String, Object> map = (Map<String, Object>)converter.convert( object ).to( Map.class );
+        if (map == null || map.isEmpty())
+            return Collections.emptyList();
+
+        if (path.startsWith("/"))
+            path = path.substring(1);
+        String[] pathParts = path.split("/");
+        if (pathParts.length <= 0)
+            return Collections.emptyList();
+
+        List<String> contexts = Arrays.asList(pathParts);
+        List<Object> values = new ArrayList<>();
+
+        return valuesAt("", map, contexts, 0, values);
+    }
+
+    private Collection<?> valuesAt(String context, Map<String, Object> objectMap, List<String> contexts, int currentIndex, List<Object> values) {
+        List<Object> result = new ArrayList<>();
+        String currentContext = context + contexts.get(currentIndex);
+        Object o = objectMap.get(currentContext);
+        if (o instanceof Map)
+            toString();
+        if (o instanceof List) {
+            @SuppressWarnings( "unchecked" )
+            List<Object> l = (List<Object>)o;
+            if (currentIndex == contexts.size() - 1) {
+                // We are at the end, so just add the collection
+                result.add(l);
+                return result;
+            }
+
+            currentContext = "/" + contexts.get(++currentIndex);
+            for (Object o2 : l)
+                result.addAll(valuesAt(currentContext, o2));
+        } else {
+            result.add( o );
+        }
+
+        return result;
     }
 }

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchemaImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchemaImpl.java
@@ -111,8 +111,6 @@ public class SchemaImpl
         List<Object> result = new ArrayList<>();
         String currentContext = context + contexts.get(currentIndex);
         Object o = objectMap.get(currentContext);
-        if (o instanceof Map)
-            toString();
         if (o instanceof List) {
             @SuppressWarnings( "unchecked" )
             List<Object> l = (List<Object>)o;

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizerImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizerImpl.java
@@ -66,9 +66,10 @@ public class SchematizerImpl implements Schematizer {
             // TODO: some validation of the Map here would be good
             SchemaImpl schema = new SchemaImpl(name);
             Object rootMap = map.get("/");
-            Node.DTO rootDTO = new StandardConverter().convert( rootMap ).to( Node.DTO.class );
+            Node.DTO rootDTO = new StandardConverter().convert(rootMap).to(Node.DTO.class);
             Map<String, NodeImpl> allNodes = new HashMap<>();
             NodeImpl root = new NodeImpl(rootDTO, "", new Instantiator(classloaders), allNodes);
+            associateChildNodes(root);
             schema.add(root);
             schema.add(allNodes);
             return Optional.of(schema);
@@ -184,7 +185,7 @@ public class SchematizerImpl implements Schematizer {
             rootNode = new NodeImpl(contextPath, targetCls, false, contextPath + "/");
         schema.add(rootNode);
         Map<String, NodeImpl> m = createMapFromDTO(name, targetCls, ref, contextPath, rules, schematizer);
-        m.values().stream().forEach(n -> n.parent(rootNode));
+        processNodeParentsAndFields(rootNode, m);
         m.values().stream().filter(v -> v.absolutePath().equals(rootNode.absolutePath() + v.name())).forEach(v -> rootNode.add(v));
         schema.add(m);
         return schema;
@@ -201,10 +202,6 @@ public class SchematizerImpl implements Schematizer {
         SchemaImpl schema = new SchemaImpl(name);
         NodeImpl node = new NodeImpl(contextPath, targetCls, isCollection, contextPath + "/");
         schema.add(node);
-//        Map<String, NodeImpl> m = createMapFromDTO(name, targetCls, ref, contextPath, rules, schematizer);
-//        m.values().stream().forEach(n -> n.parent(node));
-//        m.values().stream().filter(v -> v.absolutePath().equals(node.absolutePath() + v.name())).forEach(v -> node.add(v));
-//        schema.add(m);
         return schema;
     }
 
@@ -405,6 +402,38 @@ public class SchematizerImpl implements Schematizer {
 
             // Nothing to do. Return Object.class as the fallback
             return Object.class;
+        }
+    }
+
+    static private void processNodeParentsAndFields(NodeImpl rootNode, Map<String, NodeImpl> map) {
+        for(NodeImpl n : map.values()) {
+            if (n.parent() != null)
+                continue;
+            n.parent(rootNode);
+            String fieldName = n.name();
+            Class<?> parentClass = rawClassOf(rootNode.type());
+            try {
+                Field field = parentClass.getField(fieldName);
+                n.field(field);
+            } catch ( NoSuchFieldException e ) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    static private void associateChildNodes(NodeImpl rootNode) {
+        for (NodeImpl child: rootNode.childrenInternal().values()) {
+            child.parent(rootNode);
+            String fieldName = child.name();
+            Class<?> parentClass = rawClassOf(rootNode.type());
+            try {
+                Field field = parentClass.getField(fieldName);
+                child.field(field);
+            } catch ( NoSuchFieldException e ) {
+                e.printStackTrace();
+            }            
+
+            associateChildNodes(child);
         }
     }
 }

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizerImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizerImpl.java
@@ -16,11 +16,14 @@
  */
 package org.apache.felix.schematizer.impl;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -282,8 +285,10 @@ public class SchematizerImpl implements Schematizer {
                     Class<?> collectionType;
                     if (collectionTypeAnnotation != null)
                         collectionType = collectionTypeAnnotation.value();
+                    else if (hasCollectionTypeAnnotation(field))
+                        collectionType = collectionTypeOf(field);
                     else
-                        collectionType = Object.class;
+                        collectionType = Object.class;                        
                     node = new CollectionNode(
                             field.getName(),
                             collectionType,
@@ -434,6 +439,36 @@ public class SchematizerImpl implements Schematizer {
             }            
 
             associateChildNodes(child);
+        }
+    }
+
+    static private boolean hasCollectionTypeAnnotation(Field field) {
+        if (field == null)
+            return false;
+
+        Annotation[] annotations = field.getAnnotations();
+        if (annotations.length == 0)
+            return false;
+
+        return Arrays.stream(annotations)
+            .map(a -> a.annotationType().getName())
+            .anyMatch(a -> "CollectionType".equals(a.substring(a.lastIndexOf(".") + 1) ));
+    }
+
+    static private Class<?> collectionTypeOf(Field field) {
+        Annotation[] annotations = field.getAnnotations();
+
+        Annotation annotation = Arrays.stream(annotations)
+            .filter(a -> "CollectionType".equals(a.annotationType().getName().substring(a.annotationType().getName().lastIndexOf(".") + 1) ))
+            .findFirst()
+            .get();
+
+        try {
+            Method m = annotation.annotationType().getMethod("value");
+            Class<?> value = (Class<?>)m.invoke(annotation, null);
+            return value;            
+        } catch ( Exception e ) {
+            return null;
         }
     }
 }

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizerImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizerImpl.java
@@ -41,6 +41,7 @@ import org.apache.felix.schematizer.Schema;
 import org.apache.felix.schematizer.Schematizer;
 import org.apache.felix.schematizer.TypeRule;
 import org.osgi.dto.DTO;
+import org.osgi.util.converter.StandardConverter;
 import org.osgi.util.converter.TypeReference;
 
 public class SchematizerImpl implements Schematizer {
@@ -64,9 +65,10 @@ public class SchematizerImpl implements Schematizer {
         try {
             // TODO: some validation of the Map here would be good
             SchemaImpl schema = new SchemaImpl(name);
-            Node.DTO rootDTO = map.get("/");
+            Object rootMap = map.get("/");
+            Node.DTO rootDTO = new StandardConverter().convert( rootMap ).to( Node.DTO.class );
             Map<String, NodeImpl> allNodes = new HashMap<>();
-            NodeImpl root = new NodeImpl(rootDTO, "", instantiator, allNodes);
+            NodeImpl root = new NodeImpl(rootDTO, "", new Instantiator(classloaders), allNodes);
             schema.add(root);
             schema.add(allNodes);
             return Optional.of(schema);
@@ -271,9 +273,7 @@ public class SchematizerImpl implements Schematizer {
                 Map<String, NodeImpl> allNodes = embedded.toMapInternal();
                 allNodes.remove(path + "/");
                 result.putAll(allNodes);
-                Map<String, NodeImpl> childNodes = new HashMap<>();
-                allNodes.keySet().stream()
-                    .forEach( k -> {String k2 = k.replace(path, ""); childNodes.put(k2, allNodes.get(k));} );
+                Map<String, NodeImpl> childNodes = extractChildren(path, allNodes);
                 node.add(childNodes);
             } else {
                 Type fieldType = field.getType();
@@ -302,9 +302,7 @@ public class SchematizerImpl implements Schematizer {
                         Map<String, NodeImpl> allNodes = embedded.toMapInternal();
                         allNodes.remove(path + "/");
                         result.putAll(allNodes);
-                        Map<String, NodeImpl> childNodes = new HashMap<>();
-                        allNodes.keySet().stream()
-                            .forEach( k -> {String k2 = k.replace(path, ""); childNodes.put(k2, allNodes.get(k));} );
+                        Map<String, NodeImpl> childNodes = extractChildren(path, allNodes);
                         node.add(childNodes);
                     }
                 }
@@ -322,9 +320,7 @@ public class SchematizerImpl implements Schematizer {
                     Map<String, NodeImpl> allNodes = embedded.toMapInternal();
                     allNodes.remove(path + "/");
                     result.putAll(allNodes);
-                    Map<String, NodeImpl> childNodes = new HashMap<>();
-                    allNodes.keySet().stream()
-                        .forEach( k -> {String k2 = k.replace(path, ""); childNodes.put(k2, allNodes.get(k));} );
+                    Map<String, NodeImpl> childNodes = extractChildren(path, allNodes);
                     node.add(childNodes);
                 } else {
                     node = new NodeImpl(
@@ -342,6 +338,17 @@ public class SchematizerImpl implements Schematizer {
             // TODO print warning??
             return;
         }
+    }
+
+    private static Map<String, NodeImpl> extractChildren( String path, Map<String, NodeImpl> allNodes ) {
+        final Map<String, NodeImpl> children = new HashMap<>();
+        for (String key : allNodes.keySet()) {
+            String newKey = key.replace(path, "");
+            if (!newKey.substring(1).contains("/"))
+                children.put( newKey, allNodes.get(key));
+        }
+
+        return children;
     }
 
     private static SchemaImpl handleInvalid() {
@@ -372,19 +379,32 @@ public class SchematizerImpl implements Schematizer {
         return typeRef;
     }
 
-    /**
-     * In an OSGi environment, this is too naive, and will quickly break down.
-     * Consider it more as a placeholder for now.
-     */
-    private static final Instantiator instantiator = new Instantiator();
     public static class Instantiator implements Function<String, Type> {
+        private final List<ClassLoader> classloaders = new ArrayList<>();
+
+        public Instantiator(List<ClassLoader> aClassLoadersList) {
+            classloaders.addAll( aClassLoadersList );
+        }
+
         @Override
         public Type apply(String className) {
-            try {
-                return Class.forName(className);
-            } catch ( ClassNotFoundException e ) {
-                return Object.class;
+            for (ClassLoader cl : classloaders) {
+                try {
+                    return cl.loadClass(className);
+                } catch (ClassNotFoundException e) {
+                    // Try next
+                }
             }
+
+            // Could not find the class. Try "this" ClassLoader
+            try {
+                return getClass().getClassLoader().loadClass(className);
+            } catch (ClassNotFoundException e) {
+                // Too bad
+            }
+
+            // Nothing to do. Return Object.class as the fallback
+            return Object.class;
         }
     }
 }

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizerImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizerImpl.java
@@ -20,12 +20,14 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -45,6 +47,7 @@ public class SchematizerImpl implements Schematizer {
 
     private final Map<String, SchemaImpl> schemas = new HashMap<>();
     private volatile Map<String, Map<String, Object>> typeRules = new HashMap<>();
+    private final List<ClassLoader> classloaders = new ArrayList<>();
 
     @Override
     public Optional<Schema> get(String name) {
@@ -105,6 +108,13 @@ public class SchematizerImpl implements Schematizer {
             typeRules.put(name, new HashMap<>());
 
         return typeRules.get(name);
+    }
+
+    @Override
+    public Schematizer usingLookup( ClassLoader classloader ) {
+        if (classloader != null)
+            classloaders.add(classloader);
+        return this;
     }
 
     /**

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizerImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizerImpl.java
@@ -188,8 +188,8 @@ public class SchematizerImpl implements Schematizer {
             rootNode = new NodeImpl(contextPath, targetCls, false, contextPath + "/");
         schema.add(rootNode);
         Map<String, NodeImpl> m = createMapFromDTO(name, targetCls, ref, contextPath, rules, schematizer);
-        processNodeParentsAndFields(rootNode, m);
         m.values().stream().filter(v -> v.absolutePath().equals(rootNode.absolutePath() + v.name())).forEach(v -> rootNode.add(v));
+        associateChildNodes( rootNode );
         schema.add(m);
         return schema;
     }
@@ -407,22 +407,6 @@ public class SchematizerImpl implements Schematizer {
 
             // Nothing to do. Return Object.class as the fallback
             return Object.class;
-        }
-    }
-
-    static private void processNodeParentsAndFields(NodeImpl rootNode, Map<String, NodeImpl> map) {
-        for(NodeImpl n : map.values()) {
-            if (n.parent() != null)
-                continue;
-            n.parent(rootNode);
-            String fieldName = n.name();
-            Class<?> parentClass = rawClassOf(rootNode.type());
-            try {
-                Field field = parentClass.getField(fieldName);
-                n.field(field);
-            } catch ( NoSuchFieldException e ) {
-                e.printStackTrace();
-            }
         }
     }
 

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizingConverterBuilderImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizingConverterBuilderImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.felix.schematizer.impl;
+
+import java.lang.reflect.Type;
+
+import org.osgi.util.converter.Converter;
+import org.osgi.util.converter.ConverterBuilder;
+import org.osgi.util.converter.Rule;
+import org.osgi.util.converter.StandardConverter;
+import org.osgi.util.converter.TypeReference;
+import org.osgi.util.function.Function;
+
+public class SchematizingConverterBuilderImpl implements ConverterBuilder {
+
+    private final ConverterBuilder builder = new StandardConverter().newConverterBuilder();
+
+    @Override
+    public Converter build()
+    {
+        Converter converter = builder.build(); 
+        return new SchematizingConverterImpl(converter);
+    }
+
+    @Override
+    public <F, T> ConverterBuilder rule( Rule<F, T> rule )
+    {
+        return builder.rule(rule);
+    }
+
+    @Override
+    public <F, T> ConverterBuilder rule( Class<F> fromCls, Class<T> toCls, Function<F, T> toFun, Function<T, F> fromFun )
+    {
+        return builder.rule(fromCls, toCls, toFun, fromFun);
+    }
+
+    @Override
+    public <F, T> ConverterBuilder rule( TypeReference<F> fromRef, TypeReference<T> toRef, Function<F, T> toFun, Function<T, F> fromFun )
+    {
+        return builder.rule(fromRef, toRef, toFun, fromFun);
+    }
+
+    @Override
+    public <F, T> ConverterBuilder rule( Type fromType, Type toType, Function<F, T> toFun, Function<T, F> fromFun )
+    {
+        return builder.rule(fromType, toType, toFun, fromFun);
+    }
+}

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizingConverterImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizingConverterImpl.java
@@ -28,6 +28,7 @@ public class SchematizingConverterImpl implements Schematizing, Converter {
 
     private final Converter converter;
     private Schema schema;
+    private boolean asDTO = false;
 
     public SchematizingConverterImpl(Converter c)
     {
@@ -42,6 +43,17 @@ public class SchematizingConverterImpl implements Schematizing, Converter {
     @Override
     public ConverterBuilder newConverterBuilder() {
         return new SchematizingConverterBuilderImpl();
+    }
+
+    @Override
+    public Converter asDTO() {
+        asDTO = true;
+        return converter;
+    }
+
+    @Override
+    public boolean isDTOType() {
+        return asDTO;
     }
 
     public Converter withSchema(Schema s) {

--- a/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizingConverterImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/schematizer/impl/SchematizingConverterImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.felix.schematizer.impl;
+
+import org.apache.felix.schematizer.Schema;
+import org.apache.felix.schematizer.Schematizing;
+import org.apache.felix.schematizer.SchematizingConverter;
+import org.osgi.util.converter.Converter;
+import org.osgi.util.converter.ConverterBuilder;
+import org.osgi.util.converter.Converting;
+import org.osgi.util.converter.StandardConverter;
+
+public class SchematizingConverterImpl implements Schematizing, Converter {
+
+    private final Converter converter;
+    private Schema schema;
+
+    public SchematizingConverterImpl(Converter c)
+    {
+        converter = c;
+    }
+
+    @Override
+    public Converting convert(Object obj) {
+        return converter.convert(obj);
+    }
+
+    @Override
+    public ConverterBuilder newConverterBuilder() {
+        return new SchematizingConverterBuilderImpl();
+    }
+
+    public Converter withSchema(Schema s) {
+        schema = s;
+        return this;
+    }
+
+    public Schema getSchema() {
+        return schema;
+    }
+}

--- a/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonDeserializingImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonDeserializingImpl.java
@@ -44,6 +44,7 @@ public class JsonDeserializingImpl<T> implements Deserializing<T> {
     private final Object target;
     private Converter converter;
     private Schema schema;
+    private boolean asDTO = false;
 
     public JsonDeserializingImpl(Converter c, Object t) {
         converter = c;
@@ -54,8 +55,11 @@ public class JsonDeserializingImpl<T> implements Deserializing<T> {
     public JsonDeserializingImpl<T> with(Converter c)
     {
         converter = c;
-        if(converter instanceof Schematizing)
-            schema = ((Schematizing)converter).getSchema();
+        if(converter instanceof Schematizing) {
+            Schematizing s = (Schematizing)converter;
+            schema = s.getSchema();
+            asDTO = s.isDTOType();
+        }
         return this;
     }
 
@@ -70,7 +74,10 @@ public class JsonDeserializingImpl<T> implements Deserializing<T> {
         if (schema != null)
             return deserialize(m);
 
-        return converter.convert(m).to(clazz);
+        if (asDTO)
+            return converter.convert(m).targetAs(DTO.class).to(clazz);
+        else
+            return converter.convert(m).to(clazz);
     }
 
     @Override
@@ -210,6 +217,8 @@ public class JsonDeserializingImpl<T> implements Deserializing<T> {
 
     @SuppressWarnings( "unchecked" )
     private <V extends Collection<?>>V instantiateCollection(Class<V> collectionClass) {
+        if (collectionClass == null)
+            return (V)new ArrayList<V>();
         if (Collection.class.equals(collectionClass) || List.class.isAssignableFrom(collectionClass))
             return (V)new ArrayList<V>();
         else

--- a/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonDeserializingImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonDeserializingImpl.java
@@ -31,6 +31,8 @@ import java.util.Scanner;
 
 import org.apache.felix.schematizer.Node;
 import org.apache.felix.schematizer.Schema;
+import org.apache.felix.schematizer.Schematizing;
+import org.apache.felix.schematizer.SchematizingConverter;
 import org.apache.felix.schematizer.impl.Util;
 import org.osgi.dto.DTO;
 import org.osgi.service.serializer.Deserializing;
@@ -52,13 +54,8 @@ public class JsonDeserializingImpl<T> implements Deserializing<T> {
     public JsonDeserializingImpl<T> with(Converter c)
     {
         converter = c;
-        return this;
-    }
-
-    public JsonDeserializingImpl<T> withContext(Object obj)
-    {
-        if(obj instanceof Schema)
-            schema = (Schema)obj;
+        if(converter instanceof Schematizing)
+            schema = ((Schematizing)converter).getSchema();
         return this;
     }
 
@@ -144,6 +141,8 @@ public class JsonDeserializingImpl<T> implements Deserializing<T> {
                 try {
                     Field f = targetCls.getField(entry.getKey().toString());
                     Object val = entry.getValue();
+                    if (val == null)
+                        continue;
                     String path = contextPath + f.getName();
                     Optional<Node> opt = schema.nodeAtPath(path);
                     if (opt.isPresent()) {

--- a/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonParser.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonParser.java
@@ -122,7 +122,10 @@ public class JsonParser {
         case 'N':
             return null;
         default:
-            return Long.parseLong(jsonValue);
+            if (jsonValue.contains("."))
+                return Double.parseDouble(jsonValue);
+            else
+                return Long.parseLong(jsonValue);
         }
     }
 

--- a/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonParser.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonParser.java
@@ -19,6 +19,7 @@ package org.apache.felix.serializer.impl.json;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -122,10 +123,7 @@ public class JsonParser {
         case 'N':
             return null;
         default:
-            if (jsonValue.contains("."))
-                return Double.parseDouble(jsonValue);
-            else
-                return Long.parseLong(jsonValue);
+            return Long.parseLong(jsonValue);
         }
     }
 
@@ -148,7 +146,11 @@ public class JsonParser {
     }
 
     private static List<String> parseKeyValueListRaw(String jsonKeyValueList) {
-        jsonKeyValueList = jsonKeyValueList + ","; // append comma to simplify parsing
+        if (jsonKeyValueList.trim().isEmpty())
+            return Collections.emptyList();
+        // Append comma to simplify parsing, if there is not already a trailing comma
+        if (!jsonKeyValueList.endsWith(","))
+                jsonKeyValueList = jsonKeyValueList + ",";
         List<String> elements = new ArrayList<>();
 
         int i=0;

--- a/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonParser.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonParser.java
@@ -131,6 +131,10 @@ public class JsonParser {
             throw new IllegalArgumentException("Malformatted JSON object: " + jsonObject);
 
         jsonObject = jsonObject.substring(1, jsonObject.length() - 1);
+
+        if (jsonObject.isEmpty())
+            return null;
+
         Map<String, Object> values = new HashMap<>();
         for (String element : parseKeyValueListRaw(jsonObject)) {
             Pair<String, Object> pair = parseKeyValue(element);

--- a/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonParser.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonParser.java
@@ -123,7 +123,10 @@ public class JsonParser {
         case 'N':
             return null;
         default:
-            return Long.parseLong(jsonValue);
+            if (jsonValue.contains("."))
+                return Double.parseDouble(jsonValue);
+            else
+                return Long.parseLong(jsonValue);
         }
     }
 

--- a/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonSerializerImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonSerializerImpl.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.felix.schematizer.SchematizingConverter;
 import org.osgi.service.serializer.Serializer;
 import org.osgi.service.serializer.Serializing;
 import org.osgi.util.converter.Converter;
@@ -33,7 +34,7 @@ import org.osgi.util.converter.TypeReference;
 public class JsonSerializerImpl implements Serializer {
     private final Map<String, Object> configuration = new ConcurrentHashMap<>();
     private final ThreadLocal<Boolean> threadLocal = new ThreadLocal<>();
-    private final Converter converter = new StandardConverter();
+    private final SchematizingConverter converter = new SchematizingConverter();
 
     @Override
     public <T> JsonDeserializingImpl<T> deserialize(Class<T> cls) {

--- a/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonSerializingImpl.java
+++ b/converter/schematizer/src/main/java/org/apache/felix/serializer/impl/json/JsonSerializingImpl.java
@@ -86,7 +86,7 @@ public class JsonSerializingImpl implements Serializing {
         } else if (obj instanceof Collection) {
             return encodeCollection((Collection) obj);
         } else if (obj instanceof DTO) {
-            return encodeMap(converter.convert(obj).to(Map.class));
+            return encodeMap(converter.convert(obj).sourceAs(DTO.class).to(Map.class));
         } else if (obj.getClass().isArray()) {
             return encodeCollection(asCollection(obj));
         } else if (obj instanceof Number) {

--- a/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/CollectionType.java
+++ b/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/CollectionType.java
@@ -1,0 +1,12 @@
+package org.apache.felix.schematizer.impl;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface CollectionType {
+    Class<?> value() default Object.class;
+}

--- a/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/CollectionType.java
+++ b/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/CollectionType.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.felix.schematizer.impl;
 
 import java.lang.annotation.ElementType;

--- a/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/MyDTO4.java
+++ b/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/MyDTO4.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import org.osgi.dto.DTO;
 
-public class MyDTO3<T> extends DTO {
+public class MyDTO4 extends DTO {
     public enum Count { ONE, TWO, THREE }
 
     public Count count;
@@ -29,6 +29,7 @@ public class MyDTO3<T> extends DTO {
 
     public long pong;
 
-    public List<T> embedded;
+    @org.apache.felix.schematizer.impl.CollectionType(MyEmbeddedDTO.class)
+    public List<MyEmbeddedDTO> embedded;
 }
 

--- a/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/SchemaTest.java
+++ b/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/SchemaTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.felix.schematizer.Schema;
-import org.apache.felix.schematizer.impl.MyDTO3.Count;
+import org.apache.felix.schematizer.impl.MyEmbeddedDTO.Alpha;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,9 +31,7 @@ import org.osgi.util.converter.TypeReference;
 
 import junit.framework.AssertionFailedError;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class SchemaTest {
     private SchematizerImpl schematizer;
@@ -70,7 +68,7 @@ public class SchemaTest {
         MyDTO3<MyEmbeddedDTO2<String>> dto = new MyDTO3<>();
         dto.ping = "lalala";
         dto.pong = Long.MIN_VALUE;
-        dto.count = Count.ONE;
+        dto.count = MyDTO3.Count.ONE;
         dto.embedded = new ArrayList<>();
         dto.embedded.add(embedded1);
         dto.embedded.add(embedded2);
@@ -78,9 +76,48 @@ public class SchemaTest {
 
         assertEquals("lalala", s.valuesAt("/ping", dto).iterator().next());
         assertEquals(Long.MIN_VALUE, s.valuesAt("/pong", dto).iterator().next());
-        assertEquals(Count.ONE, s.valuesAt("/count", dto).iterator().next());
+        assertEquals(MyDTO3.Count.ONE, s.valuesAt("/count", dto).iterator().next());
         assertNotNull(s.valuesAt("/embedded", dto));
+        Object embeddedList = s.valuesAt("/embedded", dto).iterator().next();
+        assertNotNull(embeddedList);
+        assertTrue(embeddedList instanceof List);
+        assertFalse(((List<?>)embeddedList).isEmpty());
+        Object embeddedObject = ((List<?>)embeddedList).get(0);
+        assertTrue(embeddedObject instanceof MyEmbeddedDTO2);
         assertListEquals(Arrays.asList(new String[]{"value1", "value2", "value3"}), s.valuesAt("/embedded/value", dto));
+    }
+
+    @Test
+    public void testEmbeddedValues() {
+        Optional<Schema> opt = schematizer
+                .rule("MyDTO", new TypeReference<MyDTO>(){})
+                .rule("MyDTO", "/embedded", new TypeReference<MyEmbeddedDTO>(){})
+                .get("MyDTO");
+
+        assertTrue(opt.isPresent());
+        Schema s = opt.get();
+        assertNotNull(s);
+
+        MyEmbeddedDTO embedded = new MyEmbeddedDTO();
+        embedded.alpha = Alpha.A;
+        embedded.marco = "mmmm";
+        embedded.polo = 66;
+
+        MyDTO dto = new MyDTO();
+        dto.ping = "lalala";
+        dto.pong = Long.MIN_VALUE;
+        dto.count = MyDTO.Count.ONE;
+        dto.embedded = embedded;
+
+        assertEquals("lalala", s.valuesAt("/ping", dto).iterator().next());
+        assertEquals(Long.MIN_VALUE, s.valuesAt("/pong", dto).iterator().next());
+        assertEquals(MyDTO.Count.ONE, s.valuesAt("/count", dto).iterator().next());
+        assertNotNull(s.valuesAt("/embedded", dto));
+        Object embeddedObject = s.valuesAt("/embedded", dto).iterator().next();
+        assertTrue(embeddedObject instanceof MyEmbeddedDTO);
+        assertEquals(Alpha.A, s.valuesAt("/embedded/alpha", dto).iterator().next());
+        assertEquals("mmmm", s.valuesAt("/embedded/marco", dto).iterator().next());
+        assertEquals(66L, s.valuesAt("/embedded/polo", dto).iterator().next());
     }
 
     @Test
@@ -102,7 +139,7 @@ public class SchemaTest {
         MyDTO3<MyEmbeddedDTO2<String>> dto = new MyDTO3<>();
         dto.ping = "lalala";
         dto.pong = Long.MIN_VALUE;
-        dto.count = Count.ONE;
+        dto.count = MyDTO3.Count.ONE;
         dto.embedded = new ArrayList<>();
         dto.embedded.add(embedded1);
         dto.embedded.add(embedded2);
@@ -110,7 +147,7 @@ public class SchemaTest {
 
         assertEquals("lalala", s.valuesAt("/ping", dto).iterator().next());
         assertEquals(Long.MIN_VALUE, s.valuesAt("/pong", dto).iterator().next());
-        assertEquals(Count.ONE, s.valuesAt("/count", dto).iterator().next());
+        assertEquals(MyDTO3.Count.ONE, s.valuesAt("/count", dto).iterator().next());
         assertNotNull(s.valuesAt("/embedded", dto));
         assertListEquals(Arrays.asList(new String[]{null, null, null}), s.valuesAt("/embedded/value", dto));
     }

--- a/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/SchemaTest.java
+++ b/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/SchemaTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.felix.schematizer.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.felix.schematizer.Schema;
+import org.apache.felix.schematizer.impl.MyDTO3.Count;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.util.converter.TypeReference;
+
+import junit.framework.AssertionFailedError;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class SchemaTest {
+    private SchematizerImpl schematizer;
+
+    @Before
+    public void setUp() {
+        schematizer = new SchematizerImpl();
+    }
+
+    @After
+    public void tearDown() {
+        schematizer = null;
+    }
+
+    @Test
+    public void testValues() {
+        Optional<Schema> opt = schematizer
+                .rule("MyDTO", new TypeReference<MyDTO3<MyEmbeddedDTO2<String>>>(){})
+                .rule("MyDTO", "/embedded", new TypeReference<MyEmbeddedDTO2<String>>(){})
+                .rule("MyDTO", "/embedded/value", String.class)
+                .get("MyDTO");
+
+        assertTrue(opt.isPresent());
+        Schema s = opt.get();
+        assertNotNull(s);
+
+        MyEmbeddedDTO2<String> embedded1 = new MyEmbeddedDTO2<>();
+        embedded1.value = "value1";
+        MyEmbeddedDTO2<String> embedded2 = new MyEmbeddedDTO2<>();
+        embedded2.value = "value2";
+        MyEmbeddedDTO2<String> embedded3 = new MyEmbeddedDTO2<>();
+        embedded3.value = "value3";
+
+        MyDTO3<MyEmbeddedDTO2<String>> dto = new MyDTO3<>();
+        dto.ping = "lalala";
+        dto.pong = Long.MIN_VALUE;
+        dto.count = Count.ONE;
+        dto.embedded = new ArrayList<>();
+        dto.embedded.add(embedded1);
+        dto.embedded.add(embedded2);
+        dto.embedded.add(embedded3);
+
+        assertEquals("lalala", s.valuesAt("/ping", dto).iterator().next());
+        assertEquals(Long.MIN_VALUE, s.valuesAt("/pong", dto).iterator().next());
+        assertEquals(Count.ONE, s.valuesAt("/count", dto).iterator().next());
+        assertNotNull(s.valuesAt("/embedded", dto));
+        assertListEquals(Arrays.asList(new String[]{"value1", "value2", "value3"}), s.valuesAt("/embedded/value", dto));
+    }
+
+    @SuppressWarnings( { "rawtypes", "unchecked" } )
+    private boolean assertListEquals(List<?> expected, Collection<?> actual) {
+        if (expected == null || actual == null)
+            throw new AssertionFailedError("The collection is null");
+
+        if (expected.size() != actual.size())
+            throw new AssertionFailedError("Expected list size of " + expected.size() + ", but was: " + actual.size());
+
+        List actualList = new ArrayList<>();
+        if (actual instanceof List)
+            actualList = (List)actual;
+        else
+            actualList.addAll(actual);
+
+        for (int i = 0; i < actual.size(); i++)
+            assertEquals(expected.get(i), actualList.get(i));
+
+        return true;
+    }
+}

--- a/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/SchemaTest.java
+++ b/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/SchemaTest.java
@@ -83,6 +83,38 @@ public class SchemaTest {
         assertListEquals(Arrays.asList(new String[]{"value1", "value2", "value3"}), s.valuesAt("/embedded/value", dto));
     }
 
+    @Test
+    public void testNullValues() {
+        Optional<Schema> opt = schematizer
+                .rule("MyDTO", new TypeReference<MyDTO3<MyEmbeddedDTO2<String>>>(){})
+                .rule("MyDTO", "/embedded", new TypeReference<MyEmbeddedDTO2<String>>(){})
+                .rule("MyDTO", "/embedded/value", String.class)
+                .get("MyDTO");
+
+        assertTrue(opt.isPresent());
+        Schema s = opt.get();
+        assertNotNull(s);
+
+        MyEmbeddedDTO2<String> embedded1 = new MyEmbeddedDTO2<>();
+        MyEmbeddedDTO2<String> embedded2 = new MyEmbeddedDTO2<>();
+        MyEmbeddedDTO2<String> embedded3 = new MyEmbeddedDTO2<>();
+
+        MyDTO3<MyEmbeddedDTO2<String>> dto = new MyDTO3<>();
+        dto.ping = "lalala";
+        dto.pong = Long.MIN_VALUE;
+        dto.count = Count.ONE;
+        dto.embedded = new ArrayList<>();
+        dto.embedded.add(embedded1);
+        dto.embedded.add(embedded2);
+        dto.embedded.add(embedded3);
+
+        assertEquals("lalala", s.valuesAt("/ping", dto).iterator().next());
+        assertEquals(Long.MIN_VALUE, s.valuesAt("/pong", dto).iterator().next());
+        assertEquals(Count.ONE, s.valuesAt("/count", dto).iterator().next());
+        assertNotNull(s.valuesAt("/embedded", dto));
+        assertListEquals(Arrays.asList(new String[]{null, null, null}), s.valuesAt("/embedded/value", dto));
+    }
+
     @SuppressWarnings( { "rawtypes", "unchecked" } )
     private boolean assertListEquals(List<?> expected, Collection<?> actual) {
         if (expected == null || actual == null)

--- a/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/SchematizerServiceTest.java
+++ b/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/SchematizerServiceTest.java
@@ -289,6 +289,45 @@ public class SchematizerServiceTest {
         assertEquals("::::count::embedded::alpha::marco::polo::ping::pong", sb.toString());
     }
 
+    @Test
+    public void testGetParentNode() {
+        Optional<Schema> opt = schematizer
+                .rule("MyDTO", new TypeReference<MyDTO>(){})
+                .rule("MyDTO", "/embedded", new TypeReference<MyEmbeddedDTO>(){})
+                .get("MyDTO");
+
+        assertTrue(opt.isPresent());
+        Schema s = opt.get();
+        assertNotNull(s);
+        Optional<Node> embeddedNode = s.nodeAtPath("/embedded/marco");
+        assertTrue(embeddedNode.isPresent());
+        Optional<Node> parentNode = s.parentOf(embeddedNode.get());
+        assertTrue(parentNode.isPresent());
+        Optional<Node> grandparentNode = s.parentOf(parentNode.get());
+        assertTrue(grandparentNode.isPresent());
+        assertEquals("/", grandparentNode.get().absolutePath());
+    }
+
+    @Test
+    public void testGetParentNode2() {
+        Optional<Schema> opt = schematizer
+                .rule("MyDTO", new TypeReference<MyDTO3<MyEmbeddedDTO2<String>>>(){})
+                .rule("MyDTO", "/embedded", new TypeReference<MyEmbeddedDTO2<String>>(){})
+                .rule("MyDTO", "/embedded/value", String.class)
+                .get("MyDTO");
+
+        assertTrue(opt.isPresent());
+        Schema s = opt.get();
+        assertNotNull(s);
+        Optional<Node> embeddedNode = s.nodeAtPath("/embedded/value");
+        assertTrue(embeddedNode.isPresent());
+        Optional<Node> parentNode = s.parentOf(embeddedNode.get());
+        assertTrue(parentNode.isPresent());
+        Optional<Node> grandparentNode = s.parentOf(parentNode.get());
+        assertTrue(grandparentNode.isPresent());
+        assertEquals("/", grandparentNode.get().absolutePath());
+    }
+
     private void assertNodeEquals(String name, String path, boolean isCollection, Object type, boolean fieldNotNull, Node node) {
         assertNotNull(node);
         assertEquals(name, node.name());

--- a/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/SchematizerServiceTest.java
+++ b/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/SchematizerServiceTest.java
@@ -136,6 +136,52 @@ public class SchematizerServiceTest {
     }
 
     @Test
+    public void testSchematizeDTOWithAnnotatedColletion() {
+        Optional<Schema> opt = schematizer
+                .rule("MyDTO4", new TypeReference<MyDTO4>(){})
+                .get("MyDTO4");
+
+        assertTrue(opt.isPresent());
+        Schema s = opt.get();
+        assertNotNull(s);
+        Node root = s.rootNode();
+        assertNodeEquals("", "/", false, MyDTO4.class, false, root);
+        assertEquals(4, root.children().size());
+        Node pingNode = root.children().get("/ping");
+        assertNodeEquals("ping", "/ping", false, String.class, true, pingNode);
+        Node pongNode = root.children().get("/pong");
+        assertNodeEquals("pong", "/pong", false, Long.class, true, pongNode);
+        Node countNode = root.children().get("/count");
+        assertNodeEquals("count", "/count", false, MyDTO4.Count.class, true, countNode);
+        Node embeddedNode = root.children().get("/embedded");
+        assertEquals(3, embeddedNode.children().size());
+        assertNodeEquals("embedded", "/embedded", true, MyEmbeddedDTO.class, true, embeddedNode);
+        Node marcoNode = embeddedNode.children().get("/marco");
+        assertNodeEquals("marco", "/embedded/marco", false, String.class, true, marcoNode);
+        Node poloNode = embeddedNode.children().get("/polo");
+        assertNodeEquals("polo", "/embedded/polo", false, Long.class, true, poloNode);
+        Node alphaNode = embeddedNode.children().get("/alpha");
+        assertNodeEquals("alpha", "/embedded/alpha", false, MyEmbeddedDTO.Alpha.class, true, alphaNode);
+
+        Node sRoot = s.nodeAtPath("/").get();
+        assertNodeEquals("", "/", false, MyDTO4.class, false, sRoot);
+        Node sPingNode = s.nodeAtPath("/ping").get();
+        assertNodeEquals("ping", "/ping", false, String.class, true, sPingNode);
+        Node sPongNode = s.nodeAtPath("/pong").get();
+        assertNodeEquals("pong", "/pong", false, Long.class, true, sPongNode);
+        Node sCountNode = s.nodeAtPath("/count").get();
+        assertNodeEquals("count", "/count", false, MyDTO4.Count.class, true, sCountNode);
+        Node sEmbeddedNode = s.nodeAtPath("/embedded").get();
+        assertNodeEquals("embedded", "/embedded", true, MyEmbeddedDTO.class, true, sEmbeddedNode);
+        Node sMarcoNode = s.nodeAtPath("/embedded/marco").get();
+        assertNodeEquals("marco", "/embedded/marco", false, String.class, true, sMarcoNode);
+        Node sPoloNode = s.nodeAtPath("/embedded/polo").get();
+        assertNodeEquals("polo", "/embedded/polo", false, Long.class, true, sPoloNode);
+        Node sAlphaNode = s.nodeAtPath("/embedded/alpha").get();
+        assertNodeEquals("alpha", "/embedded/alpha", false, MyEmbeddedDTO.Alpha.class, true, sAlphaNode);
+    }
+
+    @Test
     public void testSchematizeToMap() {
         Optional<Schema> opt = schematizer
                 .rule("MyDTO", new TypeReference<MyDTO>(){})

--- a/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/SchematizerServiceTest.java
+++ b/converter/schematizer/src/test/java/org/apache/felix/schematizer/impl/SchematizerServiceTest.java
@@ -59,40 +59,40 @@ public class SchematizerServiceTest {
         Schema s = opt.get();
         assertNotNull(s);
         Node root = s.rootNode();
-        assertNodeEquals("", "/", false, MyDTO.class, root);
+        assertNodeEquals("", "/", false, MyDTO.class, false, root);
         assertEquals(4, root.children().size());
         Node pingNode = root.children().get("/ping");
-        assertNodeEquals("ping", "/ping", false, String.class, pingNode);
+        assertNodeEquals("ping", "/ping", false, String.class, true, pingNode);
         Node pongNode = root.children().get("/pong");
-        assertNodeEquals("pong", "/pong", false, Long.class, pongNode);
+        assertNodeEquals("pong", "/pong", false, Long.class, true, pongNode);
         Node countNode = root.children().get("/count");
-        assertNodeEquals("count", "/count", false, MyDTO.Count.class, countNode);
+        assertNodeEquals("count", "/count", false, MyDTO.Count.class, true, countNode);
         Node embeddedNode = root.children().get("/embedded");
         assertEquals(3, embeddedNode.children().size());
-        assertNodeEquals("embedded", "/embedded", false, MyEmbeddedDTO.class, embeddedNode);
+        assertNodeEquals("embedded", "/embedded", false, MyEmbeddedDTO.class, true, embeddedNode);
         Node marcoNode = embeddedNode.children().get("/marco");
-        assertNodeEquals("marco", "/embedded/marco", false, String.class, marcoNode);
+        assertNodeEquals("marco", "/embedded/marco", false, String.class, true, marcoNode);
         Node poloNode = embeddedNode.children().get("/polo");
-        assertNodeEquals("polo", "/embedded/polo", false, Long.class, poloNode);
+        assertNodeEquals("polo", "/embedded/polo", false, Long.class, true, poloNode);
         Node alphaNode = embeddedNode.children().get("/alpha");
-        assertNodeEquals("alpha", "/embedded/alpha", false, MyEmbeddedDTO.Alpha.class, alphaNode);
+        assertNodeEquals("alpha", "/embedded/alpha", false, MyEmbeddedDTO.Alpha.class, true, alphaNode);
 
         Node sRoot = s.nodeAtPath("/").get();
-        assertNodeEquals("", "/", false, MyDTO.class, sRoot);
+        assertNodeEquals("", "/", false, MyDTO.class, false, sRoot);
         Node sPingNode = s.nodeAtPath("/ping").get();
-        assertNodeEquals("ping", "/ping", false, String.class, sPingNode);
+        assertNodeEquals("ping", "/ping", false, String.class, true, sPingNode);
         Node sPongNode = s.nodeAtPath("/pong").get();
-        assertNodeEquals("pong", "/pong", false, Long.class, sPongNode);
+        assertNodeEquals("pong", "/pong", false, Long.class, true, sPongNode);
         Node sCountNode = s.nodeAtPath("/count").get();
-        assertNodeEquals("count", "/count", false, MyDTO.Count.class, sCountNode);
+        assertNodeEquals("count", "/count", false, MyDTO.Count.class, true, sCountNode);
         Node sEmbeddedNode = s.nodeAtPath("/embedded").get();
-        assertNodeEquals("embedded", "/embedded", false, MyEmbeddedDTO.class, sEmbeddedNode);
+        assertNodeEquals("embedded", "/embedded", false, MyEmbeddedDTO.class, true, sEmbeddedNode);
         Node sMarcoNode = s.nodeAtPath("/embedded/marco").get();
-        assertNodeEquals("marco", "/embedded/marco", false, String.class, sMarcoNode);
+        assertNodeEquals("marco", "/embedded/marco", false, String.class, true, sMarcoNode);
         Node sPoloNode = s.nodeAtPath("/embedded/polo").get();
-        assertNodeEquals("polo", "/embedded/polo", false, Long.class, sPoloNode);
+        assertNodeEquals("polo", "/embedded/polo", false, Long.class, true, sPoloNode);
         Node sAlphaNode = s.nodeAtPath("/embedded/alpha").get();
-        assertNodeEquals("alpha", "/embedded/alpha", false, MyEmbeddedDTO.Alpha.class, sAlphaNode);
+        assertNodeEquals("alpha", "/embedded/alpha", false, MyEmbeddedDTO.Alpha.class, true, sAlphaNode);
     }
 
     @Test
@@ -107,32 +107,32 @@ public class SchematizerServiceTest {
         Schema s = opt.get();
         assertNotNull(s);
         Node root = s.rootNode();
-        assertNodeEquals("", "/", false, new TypeReference<MyDTO3<MyEmbeddedDTO2<String>>>(){}.getType(), root);
+        assertNodeEquals("", "/", false, new TypeReference<MyDTO3<MyEmbeddedDTO2<String>>>(){}.getType(), false, root);
         assertEquals(4, root.children().size());
         Node pingNode = root.children().get("/ping");
-        assertNodeEquals("ping", "/ping", false, String.class, pingNode);
+        assertNodeEquals("ping", "/ping", false, String.class, true, pingNode);
         Node pongNode = root.children().get("/pong");
-        assertNodeEquals("pong", "/pong", false, Long.class, pongNode);
+        assertNodeEquals("pong", "/pong", false, Long.class, true, pongNode);
         Node countNode = root.children().get("/count");
-        assertNodeEquals("count", "/count", false, MyDTO3.Count.class, countNode);
+        assertNodeEquals("count", "/count", false, MyDTO3.Count.class, true, countNode);
         Node embeddedNode = root.children().get("/embedded");
         assertEquals(1, embeddedNode.children().size());
-        assertNodeEquals("embedded", "/embedded", true, new TypeReference<MyEmbeddedDTO2<String>>(){}.getType(), embeddedNode);
+        assertNodeEquals("embedded", "/embedded", true, new TypeReference<MyEmbeddedDTO2<String>>(){}.getType(), true, embeddedNode);
         Node valueNode = embeddedNode.children().get("/value");
-        assertNodeEquals("value", "/embedded/value", false, String.class, valueNode);
+        assertNodeEquals("value", "/embedded/value", false, String.class, true, valueNode);
 
         Node sRoot = s.nodeAtPath("/").get();
-        assertNodeEquals("", "/", false, new TypeReference<MyDTO3<MyEmbeddedDTO2<String>>>(){}.getType(), sRoot);
+        assertNodeEquals("", "/", false, new TypeReference<MyDTO3<MyEmbeddedDTO2<String>>>(){}.getType(), false, sRoot);
         Node sPingNode = s.nodeAtPath("/ping").get();
-        assertNodeEquals("ping", "/ping", false, String.class, sPingNode);
+        assertNodeEquals("ping", "/ping", false, String.class, true, sPingNode);
         Node sPongNode = s.nodeAtPath("/pong").get();
-        assertNodeEquals("pong", "/pong", false, Long.class, sPongNode);
+        assertNodeEquals("pong", "/pong", false, Long.class, true, sPongNode);
         Node sCountNode = s.nodeAtPath("/count").get();
-        assertNodeEquals("count", "/count", false, MyDTO3.Count.class, sCountNode);
+        assertNodeEquals("count", "/count", false, MyDTO3.Count.class, true, sCountNode);
         Node sEmbeddedNode = s.nodeAtPath("/embedded").get();
-        assertNodeEquals("embedded", "/embedded", true, new TypeReference<MyEmbeddedDTO2<String>>(){}.getType(), sEmbeddedNode);
+        assertNodeEquals("embedded", "/embedded", true, new TypeReference<MyEmbeddedDTO2<String>>(){}.getType(), true, sEmbeddedNode);
         Node sValueNode = s.nodeAtPath("/embedded/value").get();
-        assertNodeEquals("value", "/embedded/value", false, String.class, sValueNode);
+        assertNodeEquals("value", "/embedded/value", false, String.class, true, sValueNode);
     }
 
     @Test
@@ -193,39 +193,39 @@ public class SchematizerServiceTest {
         assertNotNull(s);
         Node root = s.rootNode();
         assertEquals(4, root.children().size());
-        assertNodeEquals("", "/", false, MyDTO.class, root);
+        assertNodeEquals("", "/", false, MyDTO.class, false, root);
         Node pingNode = root.children().get("/ping");
-        assertNodeEquals("ping", "/ping", false, String.class, pingNode);
+        assertNodeEquals("ping", "/ping", false, String.class, true, pingNode);
         Node pongNode = root.children().get("/pong");
-        assertNodeEquals("pong", "/pong", false, Long.class, pongNode);
+        assertNodeEquals("pong", "/pong", false, Long.class, true, pongNode);
         Node countNode = root.children().get("/count");
-        assertNodeEquals("count", "/count", false, MyDTO.Count.class, countNode);
+        assertNodeEquals("count", "/count", false, MyDTO.Count.class, true, countNode);
         Node embeddedNode = root.children().get("/embedded");
         assertEquals(3, embeddedNode.children().size());
-        assertNodeEquals("embedded", "/embedded", false, MyEmbeddedDTO.class, embeddedNode);
+        assertNodeEquals("embedded", "/embedded", false, MyEmbeddedDTO.class, true, embeddedNode);
         Node marcoNode = embeddedNode.children().get("/marco");
-        assertNodeEquals("marco", "/embedded/marco", false, String.class, marcoNode);
+        assertNodeEquals("marco", "/embedded/marco", false, String.class, true, marcoNode);
         Node poloNode = embeddedNode.children().get("/polo");
-        assertNodeEquals("polo", "/embedded/polo", false, Long.class, poloNode);
+        assertNodeEquals("polo", "/embedded/polo", false, Long.class, true, poloNode);
         Node alphaNode = embeddedNode.children().get("/alpha");
-        assertNodeEquals("alpha", "/embedded/alpha", false, MyEmbeddedDTO.Alpha.class, alphaNode);
+        assertNodeEquals("alpha", "/embedded/alpha", false, MyEmbeddedDTO.Alpha.class, true, alphaNode);
 
         Node sRoot = s.nodeAtPath("/").get();
-        assertNodeEquals("", "/", false, MyDTO.class, sRoot);
+        assertNodeEquals("", "/", false, MyDTO.class, false, sRoot);
         Node sPingNode = s.nodeAtPath("/ping").get();
-        assertNodeEquals("ping", "/ping", false, String.class, sPingNode);
+        assertNodeEquals("ping", "/ping", false, String.class, true, sPingNode);
         Node sPongNode = s.nodeAtPath("/pong").get();
-        assertNodeEquals("pong", "/pong", false, Long.class, sPongNode);
+        assertNodeEquals("pong", "/pong", false, Long.class, true, sPongNode);
         Node sCountNode = s.nodeAtPath("/count").get();
-        assertNodeEquals("count", "/count", false, MyDTO.Count.class, sCountNode);
+        assertNodeEquals("count", "/count", false, MyDTO.Count.class, true, sCountNode);
         Node sEmbeddedNode = s.nodeAtPath("/embedded").get();
-        assertNodeEquals("embedded", "/embedded", false, MyEmbeddedDTO.class, sEmbeddedNode);
+        assertNodeEquals("embedded", "/embedded", false, MyEmbeddedDTO.class, true, sEmbeddedNode);
         Node sMarcoNode = s.nodeAtPath("/embedded/marco").get();
-        assertNodeEquals("marco", "/embedded/marco", false, String.class, sMarcoNode);
+        assertNodeEquals("marco", "/embedded/marco", false, String.class, true, sMarcoNode);
         Node sPoloNode = s.nodeAtPath("/embedded/polo").get();
-        assertNodeEquals("polo", "/embedded/polo", false, Long.class, sPoloNode);
+        assertNodeEquals("polo", "/embedded/polo", false, Long.class, true, sPoloNode);
         Node sAlphaNode = s.nodeAtPath("/embedded/alpha").get();
-        assertNodeEquals("alpha", "/embedded/alpha", false, MyEmbeddedDTO.Alpha.class, sAlphaNode);
+        assertNodeEquals("alpha", "/embedded/alpha", false, MyEmbeddedDTO.Alpha.class, true, sAlphaNode);
     }
 
     @Test
@@ -243,12 +243,16 @@ public class SchematizerServiceTest {
         assertEquals("::::count::embedded::alpha::marco::polo::ping::pong", sb.toString());
     }
 
-    private void assertNodeEquals(String name, String path, boolean isCollection, Object type, Node node) {
+    private void assertNodeEquals(String name, String path, boolean isCollection, Object type, boolean fieldNotNull, Node node) {
         assertNotNull(node);
         assertEquals(name, node.name());
         assertEquals(path, node.absolutePath());
         assertEquals(isCollection, node.isCollection());
         assertEquals(type, node.type());
+        if (fieldNotNull)
+            assertNotNull(node.field());
+        else
+            assertTrue(node.field() == null);
     }
 
     private void assertNodeDTOEquals(String name, String path, boolean isCollection, Class<?> type, Node.DTO node) {

--- a/converter/schematizer/src/test/java/org/apache/felix/serializer/impl/json/JsonDeserializationTest.java
+++ b/converter/schematizer/src/test/java/org/apache/felix/serializer/impl/json/JsonDeserializationTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Optional;
 
 import org.apache.felix.schematizer.Schema;
+import org.apache.felix.schematizer.SchematizingConverter;
 import org.apache.felix.schematizer.impl.SchematizerImpl;
 import org.apache.felix.serializer.impl.json.MyDTO.Count;
 import org.apache.felix.serializer.impl.json.MyEmbeddedDTO.Alpha;
@@ -34,11 +35,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class JsonDeserializationTest {
-    private Converter converter;
+    private SchematizingConverter converter;
 
     @Before
     public void setUp() {
-        converter = new StandardConverter();
+        converter = new SchematizingConverter();
     }
 
     @After
@@ -59,8 +60,6 @@ public class JsonDeserializationTest {
         dto.count = Count.TWO;
         dto.embedded = embedded;
 
-        String serialized = new JsonSerializerImpl().serialize(dto).toString();
-
         // TODO
         Optional<Schema> opt = new SchematizerImpl()
             .rule("MyDTO", new TypeReference<MyDTO>(){})
@@ -71,10 +70,10 @@ public class JsonDeserializationTest {
 
         Schema s = opt.get();
 
+        String serialized = new JsonSerializerImpl().serialize(dto).with(converter.withSchema(s)).toString();
         MyDTO result = new JsonSerializerImpl()
                 .deserialize(MyDTO.class)
-                .with(converter)
-                .withContext(s)
+                .with(converter.withSchema(s))
                 .from(serialized);
 
         assertEquals(dto.ping, result.ping);
@@ -110,8 +109,7 @@ public class JsonDeserializationTest {
         MyDTO2<MyEmbeddedDTO2<String>> result =
                 new JsonSerializerImpl()
                 .deserialize(new TypeReference<MyDTO2<MyEmbeddedDTO2<String>>>(){})
-                .with(converter)
-                .withContext(s)
+                .with(converter.withSchema(s))
                 .from(serialized);
 
         assertEquals(dto.ping, result.ping);

--- a/converter/schematizer/src/test/java/org/apache/felix/serializer/impl/json/RepositorySerializationTest.java
+++ b/converter/schematizer/src/test/java/org/apache/felix/serializer/impl/json/RepositorySerializationTest.java
@@ -74,7 +74,6 @@ public class RepositorySerializationTest
 	}
 
     @Test
-    @Ignore("davidb: I've ignore'd this test as it fails. Need to revisit once the converter has stabilized")
 	public void shouldPutAndRemoveSimpleEntitiesFromStore() {
 		simpleManager.clear();
 		final SimpleTopEntity e1 = factory.newSimpleTop( "ID01", "Value01", null );
@@ -115,9 +114,6 @@ public class RepositorySerializationTest
 	}
 
     @Test
-    @Ignore("davidb: I've @Ignore-d this test as the DTO used breaks the DTO "
-            + "contract which says that DTOs cannot contain any methods. As these "
-            + "entities contain some methods they are not recognized as DTOs")
     public void shouldPutAndRemoveComplexEntityFromStore() {
         complexManager.clear();
         assertTrue( complexManager.list().isEmpty() );
@@ -158,9 +154,6 @@ public class RepositorySerializationTest
     }
 
     @Test
-    @Ignore("davidb: I've @Ignore-d this test as the DTO used breaks the DTO "
-            + "contract which says that DTOs cannot contain any methods. As these "
-            + "entities contain some methods they are not recognized as DTOs")
     public void shouldPutAllToStore() {
         complexManager.clear();
         assertTrue( complexManager.list().isEmpty() );
@@ -211,7 +204,6 @@ public class RepositorySerializationTest
     }
 
     @Test
-    @Ignore("davidb: I've ignore'd this test as it fails. Need to revisit once the converter has stabilized")
 	public void shouldIterateThroughKeysAndValues() {
 	    simpleManager.clear();
 

--- a/converter/schematizer/src/test/java/org/apache/felix/serializer/test/objects/provider/ObjectFactory.java
+++ b/converter/schematizer/src/test/java/org/apache/felix/serializer/test/objects/provider/ObjectFactory.java
@@ -18,6 +18,7 @@ package org.apache.felix.serializer.test.objects.provider;
 
 import java.util.Collection;
 
+import org.osgi.dto.DTO;
 import org.osgi.util.converter.Converter;
 import org.osgi.util.converter.StandardConverter;
 
@@ -30,7 +31,7 @@ public class ObjectFactory
         final ComplexTopEntity top = new ComplexTopEntity();
         top.id = anId;
         top.value = aValue;
-        top.embeddedValue = cnv.convert( aMiddle ).to( ComplexMiddleEntity.class );
+        top.embeddedValue = cnv.convert( aMiddle ).sourceAs(DTO.class).to( ComplexMiddleEntity.class );
         return top;
     }
 

--- a/converter/schematizer/src/test/java/org/apache/felix/serializer/test/prevayler/DTOSerializer.java
+++ b/converter/schematizer/src/test/java/org/apache/felix/serializer/test/prevayler/DTOSerializer.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 
 import org.apache.felix.schematizer.Schema;
 import org.apache.felix.schematizer.Schematizer;
+import org.apache.felix.schematizer.SchematizingConverter;
 import org.apache.felix.schematizer.TypeRule;
 import org.apache.felix.schematizer.impl.SchematizerImpl;
 import org.apache.felix.serializer.impl.json.JsonSerializerImpl;
@@ -39,7 +40,7 @@ public class DTOSerializer<C extends CommandDTO<?>>
 {
     private static final int MARKER_LENGTH = 10;
 
-    private final Converter converter = new StandardConverter();
+    private final SchematizingConverter converter = new SchematizingConverter();
     private final JsonSerializerImpl serializer = new JsonSerializerImpl();
     private final List<TypeRule<?>> rules;
     private final Map<String, Schema> schemas = new HashMap<>();
@@ -62,8 +63,7 @@ public class DTOSerializer<C extends CommandDTO<?>>
         Schema s = schemas.get( command.name() );
         return (C)serializer
                 .deserialize( CommandDTO.class )
-                .with( converter )
-                .withContext( s )
+                .with( converter.withSchema( s ) )
                 .from( in );
     }
 
@@ -96,7 +96,8 @@ public class DTOSerializer<C extends CommandDTO<?>>
         }
 
         out.write( markerFor( command.command ) );
-        serializer.serialize( command ).to( out );
+        Schema s = schemas.get( name );
+        serializer.serialize( command ).with( converter.withSchema( s ) ).to( out );
     }
 
     private final byte[] markerFor( Command command )

--- a/converter/serializer/src/main/java/org/apache/felix/serializer/impl/json/JsonParser.java
+++ b/converter/serializer/src/main/java/org/apache/felix/serializer/impl/json/JsonParser.java
@@ -89,12 +89,24 @@ public class JsonParser {
     }
 
     private static Pair<String, Object> parseKeyValue(String jsonKeyValue) {
+        // Should be able to accept an empty key/value
+        if (jsonKeyValue.isEmpty())
+            return null;
+
         Matcher matcher = KEY_VALUE_PATTERN.matcher(jsonKeyValue);
         if (!matcher.matches() || matcher.groupCount() < 2) {
             throw new IllegalArgumentException("Malformatted JSON key-value pair: " + jsonKeyValue);
         }
 
-        return new Pair<>(matcher.group(1), parseValue(matcher.group(2)));
+        try
+        {
+            return new Pair<>(matcher.group(1), parseValue(matcher.group(2)));
+        }
+        catch ( Exception e ) {
+            // The matcher throws as exeption when there is an empty value, when it should just return null;
+            // TODO: find a better solution to solve this problem.
+            return null;
+        }
     }
 
     private static Object parseValue(String jsonValue) {
@@ -142,7 +154,8 @@ public class JsonParser {
 
         for (String element : parseKeyValueListRaw(jsonObject)) {
             Pair<String, Object> pair = parseKeyValue(element);
-            values.put(pair.key, pair.value);
+            if (pair != null)
+                values.put(pair.key, pair.value);
         }
 
         return values;


### PR DESCRIPTION
It is very nice to have the sourceAs(Class) method. In order to make it a bit more generalized and useful, this update allows the use of DTO.class to signal that the Object should be treated as a DTO.

There are times when the specific type of DTO is not known, but it is known that the Object should be treated as if it were a DTO.

Without this fix, the internal isDTOType(Class) method does not (correctly) consider the DTO class to actually be a DTO, since it is abstract and does not follow the rules for a DTO.