### PR TITLE
[FELIX-5184] Add alias for Windows Server 2012

### DIFF
--- a/framework/src/main/resources/default.properties
+++ b/framework/src/main/resources/default.properties
@@ -67,6 +67,7 @@ felix.native.osname.alias.windows8=windows 8,win32
 felix.native.osname.alias.windows9=windows 9,win32
 felix.native.osname.alias.windows10=windows 10,win32
 felix.native.osname.alias.windowsserver2008=windows server 2008,win32
+felix.native.osname.alias.windowsserver2012=windows server 2012,win32
 felix.native.osname.alias.win32=
 
 felix.service.caps=osgi.service; objectClass:List<String>=org.osgi.service.resolver.Resolver; uses:=org.osgi.service.resolver, \


### PR DESCRIPTION
default.properties were missing alias for Windows Server 2012. 

See [FELIX-5184:](https://issues.apache.org/jira/browse/FELIX-5184)