### PR TITLE
FELIX-5568: mark java.lang.management as an optional import

### DIFF
--- a/scr/bnd.bnd
+++ b/scr/bnd.bnd
@@ -37,6 +37,7 @@ Import-Package: \
  org.osgi.util.function;version="[1.0,2)", \
  org.apache.felix.service.command;resolution:=optional, \
  org.apache.felix.shell;provide:=true;resolution:=optional, \
+ java.lang.management;resolution:=optional, \
  *
 
 DynamicImport-Package: \


### PR DESCRIPTION
The import is used by the thread dump code, but the SCR can handle
the import not being there (which is the case when run on profile1 or
profile2).

Signed-off-by: Ferry Huberts <ferry.huberts@pelagic.nl>