### PR TITLE
FELIX-5613 - SCR bundle fails to start without Config Admin

### DIFF
--- a/scr/src/main/java/org/apache/felix/scr/impl/manager/RegionConfigurationSupport.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/manager/RegionConfigurationSupport.java
@@ -40,13 +40,11 @@ import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.cm.ConfigurationEvent;
-import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ConfigurationListener;
 import org.osgi.service.cm.ConfigurationPermission;
-import org.osgi.service.cm.ManagedService;
 import org.osgi.service.log.LogService;
 
-public abstract class RegionConfigurationSupport implements ConfigurationListener
+public abstract class RegionConfigurationSupport
 {
 
     private final SimpleLogger logger;
@@ -79,8 +77,17 @@ public abstract class RegionConfigurationSupport implements ConfigurationListene
         Dictionary<String, Object> props = new Hashtable<String, Object>();
         props.put( Constants.SERVICE_DESCRIPTION, "Declarative Services Configuration Support Listener" );
         props.put( Constants.SERVICE_VENDOR, "The Apache Software Foundation" );
-        this.m_registration = caBundleContext.registerService( ConfigurationListener.class, this, props );
 
+        // If RegionDelegatorSupport *directly* implements ConfigurationListener then we get NoClassDefFoundError
+        // when SCR is started without a wiring to an exporter of Config Admin API. This construction allows the
+        // class loading exception to be caught and confined.
+        ConfigurationListener serviceDelegator = new ConfigurationListener() {
+            @Override
+            public void configurationEvent(ConfigurationEvent event) {
+                RegionConfigurationSupport.this.configurationEvent(event);
+            }
+        };
+        this.m_registration = caBundleContext.registerService(ConfigurationListener.class, serviceDelegator, props );
     }
 
     public Long getBundleId()


### PR DESCRIPTION
RegionConfigurationSupport does not need to directly implement ConfigurationListener. By registering an anonymous inner class, the class loading errors are isolated to this class and do not prevent the bundle from starting.

**Testing Note**

I tried **very** hard to write a PAX Exam integration test that would prove SCR works when there is no exporter of `org.osgi.service.cm`, but I believe this is impossible due to a limitation of PAX Exam. The testing framework always contains the OSGi Compendium bundle version 4.2.0 (`org.osgi:org.osgi.compendium:4.2.0`) because it is a dependency of PAX. Compendium exports `org.osgi.service.cm` version 1.3.0. It cannot be removed as far as I can tell.

I have verified manually that SCR works in both a framework with Config Admin and a framework without Config Admin. However without an automated test it is always possible somebody will make a change that makes SCR dependent on Config Admin once again. I would suggest migrating to bnd-testing-maven-plugin as this does not pollute the testing framework with its own dependencies.