### PR TITLE
FELIX-5669 Fixing bug in ConfigurationManager that duplicates PersistenceManager caches

### DIFF
--- a/configadmin/src/main/java/org/apache/felix/cm/impl/CachingPersistenceManagerProxy.java
+++ b/configadmin/src/main/java/org/apache/felix/cm/impl/CachingPersistenceManagerProxy.java
@@ -262,4 +262,13 @@ class CachingPersistenceManagerProxy implements PersistenceManager
     {
         return new CaseInsensitiveDictionary( source );
     }
+
+    /**
+     * Checks if this proxy's wrapped {@link PersistenceManager} is equal
+     * to the given {@link PersistenceManager}.
+     * @param pm The {@link PersistenceManager} to compare to
+     */
+    boolean isProxying(PersistenceManager pm) {
+        return this.pm == pm;
+    }
 }

--- a/configadmin/src/main/java/org/apache/felix/cm/impl/ConfigurationManager.java
+++ b/configadmin/src/main/java/org/apache/felix/cm/impl/ConfigurationManager.java
@@ -846,7 +846,12 @@ public class ConfigurationManager implements BundleActivator, BundleListener
                     Object service = persistenceManagerTracker.getService( refs[i] );
                     if ( service != null )
                     {
-                        pmList.add( new CachingPersistenceManagerProxy( ( PersistenceManager ) service ) );
+                        CachingPersistenceManagerProxy pmProxy = getCachedProxyForPersistenceManager((PersistenceManager)service);
+                        if (pmProxy == null) {
+                            pmList.add(new CachingPersistenceManagerProxy((PersistenceManager) service));
+                        } else {
+                            pmList.add(pmProxy);
+                        }
                     }
                 }
 
@@ -860,6 +865,16 @@ public class ConfigurationManager implements BundleActivator, BundleListener
         return persistenceManagers;
     }
 
+    private CachingPersistenceManagerProxy getCachedProxyForPersistenceManager(final PersistenceManager pm) {
+        if (persistenceManagers != null) {
+            for (CachingPersistenceManagerProxy pmProxy : persistenceManagers) {
+                if (pmProxy.isProxying(pm)) {
+                    return pmProxy;
+                }
+            }
+        }
+        return null;
+    }
 
     private ServiceReference getServiceReference()
     {


### PR DESCRIPTION
The `ConfigurationManager` duplicates `CachingPersistenceManagerProxy`s when `getPersistenceManagers()` is called after registering a new `PersistenceManager`. Since previously created `Configuration` objects still have a reference to the old `CachingPersistenceManagerProxy`, a delete/update does not fully delete/update in all places. This fixes it to use the previous `CachingPersistenceManagerProxy` if one exists.