### PR TITLE
Change boot class loader to PlatformClassLoader on JDK9

### DIFF
--- a/framework/src/main/java/org/apache/felix/framework/BundleWiringImpl.java
+++ b/framework/src/main/java/org/apache/felix/framework/BundleWiringImpl.java
@@ -124,14 +124,24 @@ public class BundleWiringImpl implements BundleWiring
     // Statically define the default class loader for boot delegation.
     static
     {
-        ClassLoader cl = null;
+        ClassLoader cl;
         try
         {
-            Constructor ctor = BundleRevisionImpl.getSecureAction().getDeclaredConstructor(
+            //JDK 9
+            try
+            {
+                Method getPlatformClassLoader = ClassLoader.class.getMethod("getPlatformClassLoader");
+                cl = (ClassLoader) getPlatformClassLoader.invoke(null);
+            }
+            catch (NoSuchMethodException t)
+            {
+                // pre-JDK9
+                Constructor ctor = BundleRevisionImpl.getSecureAction().getDeclaredConstructor(
                     SecureClassLoader.class, new Class[] { ClassLoader.class });
-            BundleRevisionImpl.getSecureAction().setAccesssible(ctor);
-            cl = (ClassLoader) BundleRevisionImpl.getSecureAction().invoke(
+                BundleRevisionImpl.getSecureAction().setAccesssible(ctor);
+                cl = (ClassLoader) BundleRevisionImpl.getSecureAction().invoke(
                     ctor, new Object[] { null });
+            }
         }
         catch (Throwable ex)
         {


### PR DESCRIPTION
This is a first attempt at getting Felix to run on JDK9. The patch is inspired by Equinox' fix for [bug 507417](https://bugs.eclipse.org/bugs/show_bug.cgi?id=507417).

I'm not really expecting to get this merged, but rather giving a jumpstart for further JDK9 developments.