### PR TITLE
[FELIX-5698] Upgrade biz.aQute.bndlib to 3.5.0 for Java 9 GA support

### DIFF
--- a/tools/maven-bundle-plugin/pom.xml
+++ b/tools/maven-bundle-plugin/pom.xml
@@ -162,7 +162,7 @@
   <dependency>
     <groupId>biz.aQute.bnd</groupId>
     <artifactId>biz.aQute.bndlib</artifactId>
-    <version>3.3.0</version>
+    <version>3.5.0</version>
   </dependency>
   <dependency>
     <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FELIX-5698

Thanks!