### PR TITLE
[FELIX-5464] NPE in org.apache.felix.scrplugin.helper.ClassScanner

### DIFF
--- a/tools/org.apache.felix.scr.generator/src/main/java/org/apache/felix/scrplugin/helper/ClassScanner.java
+++ b/tools/org.apache.felix.scr.generator/src/main/java/org/apache/felix/scrplugin/helper/ClassScanner.java
@@ -208,7 +208,11 @@ public class ClassScanner {
             try {
                 classReader = new ClassReader(input);
             } finally {
-                input.close();
+                if(input != null) {
+                    input.close();
+                } else {
+                    log.warn("Could not open InputStream for: " + pathToClassFile);
+                }
             }
             final ClassNode classNode = new ClassNode();
             classReader.accept(classNode, SKIP_CODE | SKIP_DEBUG | SKIP_FRAMES);


### PR DESCRIPTION
Couldn't make this happen by invoking public method in a unit test, but checked for null InputStream before closing, logged warn message otherwise.