### PR TITLE
[converter] Avoid losing generics information in nested types

### DIFF
--- a/converter/converter/src/main/java/org/osgi/util/converter/ConvertingImpl.java
+++ b/converter/converter/src/main/java/org/osgi/util/converter/ConvertingImpl.java
@@ -399,7 +399,7 @@ class ConvertingImpl extends AbstractSpecifying<Converting>
 						val = converter.convert(val).sourceAsDTO().to(
 								f.getType());
 					else
-						val = converter.convert(val).to(f.getType());
+						val = converter.convert(val).to(f.getGenericType());
 					f.set(dto, val);
 				}
 			}
@@ -662,8 +662,6 @@ class ConvertingImpl extends AbstractSpecifying<Converting>
 				if (propName == null)
 					return null;
 
-				Class< ? > targetType = method.getReturnType();
-
 				Object val = m.get(propName);
 				if (val == null && keysIgnoreCase) {
 					// try in a case-insensitive way
@@ -692,7 +690,7 @@ class ConvertingImpl extends AbstractSpecifying<Converting>
 					}
 				}
 
-				return converter.convert(val).to(targetType);
+				return converter.convert(val).to(method.getGenericReturnType());
 			}
 		});
 	}

--- a/converter/converter/src/main/java/org/osgi/util/converter/ConvertingImpl.java
+++ b/converter/converter/src/main/java/org/osgi/util/converter/ConvertingImpl.java
@@ -20,12 +20,14 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -139,6 +141,18 @@ class ConvertingImpl extends AbstractSpecifying<Converting>
 			typeArguments = pt.getActualTypeArguments();
 			if (rt instanceof Class)
 				cls = (Class< ? >) rt;
+		} else if (type instanceof GenericArrayType) {
+			GenericArrayType pt = (GenericArrayType) type;
+			Type rt = pt.getGenericComponentType();
+			if (rt instanceof Class)
+				cls = (Class< ? >) rt;
+			else if (rt instanceof ParameterizedType) {
+				Type rt2 = ((ParameterizedType) rt).getRawType();
+				if(rt2 instanceof Class) {
+					cls = (Class< ? >) rt2;
+				}
+			}
+				
 		}
 		if (cls == null)
 			return null;
@@ -162,7 +176,9 @@ class ConvertingImpl extends AbstractSpecifying<Converting>
 			return res;
 
 		if (targetAsClass.isArray()) {
-			return convertToArray();
+			return convertToArray(targetAsClass.getComponentType(), targetAsClass.getComponentType());
+		} else if (type instanceof GenericArrayType) {
+			return convertToArray(targetAsClass, ((GenericArrayType)type).getGenericComponentType());
 		} else if (Collection.class.isAssignableFrom(targetAsClass)) {
 			return convertToCollectionType();
 		} else if (isMapType(targetAsClass, targetAsJavaBean, targetAsDTO)) {
@@ -250,17 +266,17 @@ class ConvertingImpl extends AbstractSpecifying<Converting>
 	}
 
 	@SuppressWarnings("unchecked")
-	private <T> T convertToArray() {
+	private <T> T convertToArray(Class<?> componentClz, Type componentType) {
 		Collection< ? > collectionView = collectionView();
 		Iterator< ? > itertor = collectionView.iterator();
 		try {
-			Object array = Array.newInstance(targetAsClass.getComponentType(),
+			Object array = Array.newInstance(componentClz,
 					collectionView.size());
 			for (int i = 0; i < collectionView.size()
 					&& itertor.hasNext(); i++) {
 				Object next = itertor.next();
 				Object converted = converter.convert(next)
-						.to(targetAsClass.getComponentType());
+						.to(componentType);
 				Array.set(array, i, converted);
 			}
 			return (T) array;
@@ -398,8 +414,10 @@ class ConvertingImpl extends AbstractSpecifying<Converting>
 					if (sourceAsDTO && DTOUtil.isDTOType(f.getType()))
 						val = converter.convert(val).sourceAsDTO().to(
 								f.getType());
-					else
-						val = converter.convert(val).to(f.getGenericType());
+					else {
+						Type genericType = reifyType(f.getGenericType());
+						val = converter.convert(val).to(genericType);
+					}
 					f.set(dto, val);
 				}
 			}
@@ -409,6 +427,66 @@ class ConvertingImpl extends AbstractSpecifying<Converting>
 			throw new ConversionException("Cannot create DTO " + targetClass,
 					e);
 		}
+	}
+
+	private Type reifyType(Type genericType) {
+		
+		if(genericType instanceof TypeVariable) {
+			String name = ((TypeVariable<?>) genericType).getName();
+			for (int i = 0; i < targetAsClass.getTypeParameters().length; i++) {
+				TypeVariable<?> typeVariable = targetAsClass.getTypeParameters()[i];
+				if(typeVariable.getName().equals(name)) {
+					genericType = typeArguments[i];
+					break;
+				}
+			}
+		} else if (genericType instanceof ParameterizedType) {
+			final ParameterizedType parameterizedType = (ParameterizedType) genericType;
+			Type[] parameters = parameterizedType.getActualTypeArguments();
+			boolean useCopy = false;
+			final Type[] copiedParameters = new Type[parameters.length];
+			
+			for(int i = 0; i < parameters.length; i++) {
+				copiedParameters[i] = reifyType(parameters[i]);
+				useCopy |= copiedParameters[i] != parameters[i];
+			}
+			
+			if(useCopy) {
+				genericType = new ParameterizedType() {
+					
+					@Override
+					public Type getRawType() {
+						return parameterizedType.getRawType();
+					}
+					
+					@Override
+					public Type getOwnerType() {
+						return parameterizedType.getOwnerType();
+					}
+					
+					@Override
+					public Type[] getActualTypeArguments() {
+						return Arrays.copyOf(copiedParameters, copiedParameters.length);
+					}
+				};
+			}
+		} else if (genericType instanceof GenericArrayType) {
+			GenericArrayType type = (GenericArrayType) genericType;
+			Type genericComponentType = type.getGenericComponentType();
+			final Type reifiedType = reifyType(genericComponentType);
+			
+			if(reifiedType != genericComponentType) {
+				genericType = new GenericArrayType() {
+					
+					@Override
+					public Type getGenericComponentType() {
+						return reifiedType;
+					}
+				};
+			}
+		}
+		
+		return genericType;
 	}
 
 	private List<String> getNames(Class< ? > cls) {
@@ -690,7 +768,8 @@ class ConvertingImpl extends AbstractSpecifying<Converting>
 					}
 				}
 
-				return converter.convert(val).to(method.getGenericReturnType());
+				Type genericType = reifyType(method.getGenericReturnType());
+				return converter.convert(val).to(genericType);
 			}
 		});
 	}

--- a/converter/converter/src/test/java/org/osgi/util/converter/ConverterTest.java
+++ b/converter/converter/src/test/java/org/osgi/util/converter/ConverterTest.java
@@ -791,6 +791,20 @@ public class ConverterTest {
             }
         }
     }
+
+    @Test
+    public void testMapToDTOWithGenericVariables() {
+    	    	Map<String, Object> dto = new HashMap<>();
+    	    	dto.put("set", new HashSet<>(Arrays.asList("foo", (int) 'o', 'o')));
+    	    	dto.put("raw", "1234");
+    	    	dto.put("array", Arrays.asList("foo", (int) 'o', 'o'));
+    	    	
+    	    	MyGenericDTOWithVariables<Character> converted = 
+    	    			converter.convert(dto).to(new TypeReference<MyGenericDTOWithVariables<Character>>() {});
+    	    	assertEquals(Character.valueOf('1'), converted.raw);
+    	    	assertArrayEquals(new Character[] {'f', 'o', 'o'}, converted.array);
+    	    	assertEquals(new HashSet<Character>(Arrays.asList('f', 'o')), converted.set);
+    }
     
     @Test
     public void testMapToDTOWithSurplusMapFiels() {
@@ -1185,6 +1199,20 @@ public class ConverterTest {
 
         MyGenericInterface converted = converter.convert(dto).to(MyGenericInterface.class);
         assertEquals(new HashSet<Character>(Arrays.asList('f', 'o')), converted.charSet());
+    }
+
+    @Test
+    public void testMapToInterfaceWithGenericVariables() {
+	    	Map<String, Object> dto = new HashMap<>();
+	    	dto.put("set", new HashSet<>(Arrays.asList("foo", (int) 'o', 'o')));
+	    	dto.put("raw", "1234");
+	    	dto.put("array", Arrays.asList("foo", (int) 'o', 'o'));
+	    	
+	    	MyGenericInterfaceWithVariables<Character> converted = 
+	    			converter.convert(dto).to(new TypeReference<MyGenericInterfaceWithVariables<Character>>() {});
+	    	assertEquals(Character.valueOf('1'), converted.raw());
+	    	assertArrayEquals(new Character[] {'f', 'o', 'o'}, converted.array());
+	    	assertEquals(new HashSet<Character>(Arrays.asList('f', 'o')), converted.set());
     }
 
     static class MyClass2 {

--- a/converter/converter/src/test/java/org/osgi/util/converter/ConverterTest.java
+++ b/converter/converter/src/test/java/org/osgi/util/converter/ConverterTest.java
@@ -750,6 +750,49 @@ public class ConverterTest {
     }
 
     @Test
+    public void testMapToDTOWithGenerics() {
+    	    Map<String, Object> dto = new HashMap<>();
+    	
+        dto.put("longList", Arrays.asList((short)999, "1000"));
+        
+        Map<String, Object> dtoMap = new LinkedHashMap<>();
+        dto.put("dtoMap", dtoMap);
+
+        Map<String, Object> subDTO1 = new HashMap<>();
+        subDTO1.put("charSet", new HashSet<>(Arrays.asList("foo", (int) 'o', 'o')));
+        dtoMap.put("zzz", subDTO1);
+
+        Map<String, Object> subDTO2 = new HashMap<>();
+        subDTO2.put("charSet", new HashSet<>(Arrays.asList('b', 'a', 'r')));
+        dtoMap.put("aaa", subDTO2);
+
+        MyDTO2 converted = converter.convert(dto).to(MyDTO2.class);
+
+        assertEquals(Arrays.asList(999L, 1000L), converted.longList);
+        Map<String, MyDTO3> nestedMap = converted.dtoMap;
+
+        // Check iteration order is preserved by iterating
+        int i=0;
+        for (Iterator<Map.Entry<String, MyDTO3>> it = nestedMap.entrySet().iterator(); it.hasNext(); i++) {
+            Map.Entry<String, MyDTO3> entry = it.next();
+            switch (i) {
+            case 0:
+                assertEquals("zzz", entry.getKey());
+                MyDTO3 dto1 = entry.getValue();
+                assertEquals(new HashSet<Character>(Arrays.asList('f', 'o')), dto1.charSet);
+                break;
+            case 1:
+                assertEquals("aaa", entry.getKey());
+                MyDTO3 dto2 = entry.getValue();
+                assertEquals(new HashSet<Character>(Arrays.asList('b', 'a', 'r')), dto2.charSet);
+                break;
+            default:
+                fail("Unexpected number of elements on map");
+            }
+        }
+    }
+    
+    @Test
     public void testMapToDTOWithSurplusMapFiels() {
         Map<String, String> m = new HashMap<>();
         m.put("foo", "bar");
@@ -1133,6 +1176,15 @@ public class ConverterTest {
         for (Iterator it = lc.iterator(); it.hasNext(); i++) {
             assertEquals(la[i], it.next());
         }
+    }
+    
+    @Test
+    public void testMapToInterfaceWithGenerics() {
+    	    Map<String, Object> dto = new HashMap<>();
+        dto.put("charSet", new HashSet<>(Arrays.asList("foo", (int) 'o', 'o')));
+
+        MyGenericInterface converted = converter.convert(dto).to(MyGenericInterface.class);
+        assertEquals(new HashSet<Character>(Arrays.asList('f', 'o')), converted.charSet());
     }
 
     static class MyClass2 {

--- a/converter/converter/src/test/java/org/osgi/util/converter/MyGenericDTOWithVariables.java
+++ b/converter/converter/src/test/java/org/osgi/util/converter/MyGenericDTOWithVariables.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.osgi.util.converter;
+
+import java.util.Set;
+
+import org.osgi.dto.DTO;
+
+public class MyGenericDTOWithVariables<T> extends DTO {
+    public Set<T> set;
+
+    public T raw;
+    
+    public T[] array;
+}

--- a/converter/converter/src/test/java/org/osgi/util/converter/MyGenericInterface.java
+++ b/converter/converter/src/test/java/org/osgi/util/converter/MyGenericInterface.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.osgi.util.converter;
+
+import java.util.Set;
+
+public interface MyGenericInterface {
+    public Set<Character> charSet();
+}

--- a/converter/converter/src/test/java/org/osgi/util/converter/MyGenericInterfaceWithVariables.java
+++ b/converter/converter/src/test/java/org/osgi/util/converter/MyGenericInterfaceWithVariables.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.osgi.util.converter;
+
+import java.util.Set;
+
+public interface MyGenericInterfaceWithVariables<T> {
+    public Set<T> set();
+
+    public T raw();
+    
+    public T[] array();
+}


### PR DESCRIPTION
The converter doesn't correctly handle conversion of nested generics as type information gets lost from the field/method the object is being converted into.

Signed-off-by: Tim Ward <timothyjward@apache.org>