### PR TITLE
FELIX-5942 - Replace wait/notify by lock/conditions in Felix to avoid freeze

### DIFF
--- a/framework/src/main/java/org/apache/felix/framework/Felix.java
+++ b/framework/src/main/java/org/apache/felix/framework/Felix.java
@@ -106,6 +106,9 @@ import java.util.StringTokenizer;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.WeakHashMap;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class Felix extends BundleImpl implements Framework
 {
@@ -131,7 +134,11 @@ public class Felix extends BundleImpl implements Framework
 
     // Lock object used to determine if an individual bundle
     // lock or the global lock can be acquired.
-    private final Object[] m_bundleLock = new Object[0];
+    private final Lock m_lock = new ReentrantLock();
+    // Notifies changes in the waiting condition of global lock acquisition
+    private final Condition m_globalLockCondition = m_lock.newCondition();
+    // Notifies changes in the waiting condition of bundle lock acquisition
+    private final Condition m_bundleLockCondition = m_lock.newCondition();
     // Keeps track of threads wanting to acquire the global lock.
     private final List<Thread> m_globalLockWaitersList = new ArrayList<Thread>();
     // The thread currently holding the global lock.
@@ -5489,10 +5496,15 @@ public class Felix extends BundleImpl implements Framework
 
     void setBundleStateAndNotify(BundleImpl bundle, int state)
     {
-        synchronized (m_bundleLock)
+        m_lock.lock();
+        try
         {
             bundle.__setState(state);
-            m_bundleLock.notifyAll();
+            m_bundleLockCondition.signalAll();
+        }
+        finally
+        {
+            m_lock.unlock();
         }
     }
 
@@ -5508,7 +5520,8 @@ public class Felix extends BundleImpl implements Framework
     void acquireBundleLock(BundleImpl bundle, int desiredStates)
         throws IllegalStateException
     {
-        synchronized (m_bundleLock)
+        m_lock.lock();
+        try
         {
             // Wait if the desired bundle is already locked by someone else
             // or if any thread has the global lock, unless the current thread
@@ -5536,7 +5549,7 @@ public class Felix extends BundleImpl implements Framework
 
                 try
                 {
-                    m_bundleLock.wait();
+                    m_bundleLockCondition.await();
                 }
                 catch (InterruptedException ex)
                 {
@@ -5555,6 +5568,10 @@ public class Felix extends BundleImpl implements Framework
             // Acquire the bundle lock.
             bundle.lock();
         }
+        finally
+        {
+            m_lock.unlock();
+        }
     }
 
     /**
@@ -5565,7 +5582,8 @@ public class Felix extends BundleImpl implements Framework
     **/
     void releaseBundleLock(BundleImpl bundle)
     {
-        synchronized (m_bundleLock)
+        m_lock.lock();
+        try
         {
             // Unlock the bundle.
             bundle.unlock();
@@ -5573,8 +5591,12 @@ public class Felix extends BundleImpl implements Framework
             // then remove it from the held lock map.
             if (bundle.getLockingThread() == null)
             {
-                m_bundleLock.notifyAll();
+                m_bundleLockCondition.signalAll();
             }
+        }
+        finally
+        {
+            m_lock.unlock();
         }
     }
 
@@ -5590,7 +5612,8 @@ public class Felix extends BundleImpl implements Framework
     **/
     boolean acquireGlobalLock()
     {
-        synchronized (m_bundleLock)
+        m_lock.lock();
+        try
         {
             // Wait as long as some other thread holds the global lock
             // and the current thread is not interrupted.
@@ -5605,11 +5628,11 @@ public class Felix extends BundleImpl implements Framework
                 // recheck for potential deadlock in acquireBundleLock()
                 // if this thread was holding a bundle lock and is now
                 // trying to promote it to a global lock.
-                m_bundleLock.notifyAll();
+                m_bundleLockCondition.signalAll();
                 // Now wait for the global lock.
                 try
                 {
-                    m_bundleLock.wait();
+                    m_globalLockCondition.await();
                 }
                 catch (InterruptedException ex)
                 {
@@ -5637,6 +5660,10 @@ public class Felix extends BundleImpl implements Framework
 
             return !interrupted;
         }
+        finally
+        {
+            m_lock.unlock();
+        }
     }
 
     /**
@@ -5646,7 +5673,8 @@ public class Felix extends BundleImpl implements Framework
     **/
     void releaseGlobalLock()
     {
-        synchronized (m_bundleLock)
+        m_lock.lock();
+        try
         {
             // Decrement the current thread's global lock count;
             if (m_globalLockThread == Thread.currentThread())
@@ -5655,7 +5683,8 @@ public class Felix extends BundleImpl implements Framework
                 if (m_globalLockCount == 0)
                 {
                     m_globalLockThread = null;
-                    m_bundleLock.notifyAll();
+                    m_globalLockCondition.signalAll();
+                    m_bundleLockCondition.signalAll();
                 }
             }
             else
@@ -5663,6 +5692,10 @@ public class Felix extends BundleImpl implements Framework
                 throw new IllegalStateException(
                     "The current thread doesn't own the global lock.");
             }
+        }
+        finally
+        {
+            m_lock.unlock();
         }
     }
 

--- a/framework/src/test/java/org/apache/felix/framework/ConcurrentClassLoaderTest.java
+++ b/framework/src/test/java/org/apache/felix/framework/ConcurrentClassLoaderTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.felix.framework;
+
+import junit.framework.TestCase;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Constants;
+import org.osgi.framework.launch.Framework;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+public class ConcurrentClassLoaderTest extends TestCase
+{
+    private static final int CONCURRENCY_LEVEL = 1000;
+
+    private File m_cacheDir;
+    private Framework m_felix;
+
+    public void testCanResolveClassInParallel() throws Exception
+    {
+        m_cacheDir = createCacheDir();
+        m_felix = createFramework(m_cacheDir);
+        m_felix.init();
+        m_felix.getBundleContext().installBundle(createBundleWithDynamicImportPackage());
+        m_felix.start();
+
+        Bundle[] bundles = m_felix.getBundleContext().getBundles();
+        assertEquals("Two, system and mine: " + Arrays.toString(bundles), 2, bundles.length);
+        final Bundle bundle = bundles[1];
+
+        // This latch ensures that all threads start at the same time
+        final CountDownLatch latch = new CountDownLatch(CONCURRENCY_LEVEL);
+        final AtomicInteger doneCount = new AtomicInteger();
+        for (int i = 0; i < CONCURRENCY_LEVEL; i++) {
+            new Thread() {
+                public void run() {
+                    try {
+                        latch.countDown();
+                        latch.await();
+                        bundle.loadClass("com.sun.this.class.does.not.exist.but.asking.for.it.must.not.block");
+                    } catch (Exception e) {
+                        // ignore
+                    } finally {
+                        doneCount.incrementAndGet();
+                    }
+                }
+            }.start();
+        }
+
+        // Wait for 1 minute for all threads to catch up
+        long timeout = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(1);
+        while (System.currentTimeMillis() < timeout && doneCount.get() != CONCURRENCY_LEVEL) {
+            Thread.sleep(50);
+        }
+
+        assertEquals("Class resolution all started", 0, latch.getCount());
+        assertEquals("Class resolution all finished", CONCURRENCY_LEVEL, doneCount.get());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+
+        m_felix.stop();
+        m_felix.waitForStop(1000);
+        m_felix = null;
+
+        delete(m_cacheDir);
+    }
+
+    private static File createCacheDir() throws IOException {
+        File cacheDir = File.createTempFile("felix-cache", ".dir");
+        cacheDir.delete();
+        cacheDir.mkdirs();
+        return cacheDir;
+    }
+
+    private static Framework createFramework(File cacheDir) {
+        Map<String, String> params = new HashMap<String, String>();
+        params.put(Constants.FRAMEWORK_SYSTEMPACKAGES,
+                   "org.osgi.framework; version=1.4.0," + "org.osgi.service.packageadmin; version=1.2.0," + "org.osgi.service.startlevel; version=1.1.0," + "org.osgi.util.tracker; version=1.3.3,"
+                           + "org.osgi.service.url; version=1.0.0");
+
+        params.put("felix.cache.profiledir", cacheDir.getPath());
+        params.put("felix.cache.dir", cacheDir.getPath());
+        params.put(Constants.FRAMEWORK_STORAGE, cacheDir.getPath());
+
+        return new Felix(params);
+    }
+
+    private static String createBundleWithDynamicImportPackage() throws IOException {
+        String manifest = "Bundle-SymbolicName: boot.test\n" + "Bundle-Version: 1.1.0\n" + "Bundle-ManifestVersion: 2\n" + "DynamicImport-Package: com.sun.*";
+
+        File f = File.createTempFile("felix-bundle", ".jar");
+        f.deleteOnExit();
+
+        Manifest mf = new Manifest(new ByteArrayInputStream(manifest.getBytes("utf-8")));
+        mf.getMainAttributes().putValue("Manifest-Version", "1.0");
+        JarOutputStream os = new JarOutputStream(new FileOutputStream(f), mf);
+        os.close();
+
+        return f.toURI().toString();
+    }
+
+    private static void delete(File file) {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    delete(child);
+                }
+            }
+        }
+        file.delete();
+    }
+}


### PR DESCRIPTION
Fix proposal for [FELIX-5942](https://issues.apache.org/jira/browse/FELIX-5942).

Instead of a single `Object` with calls to `wait` and `notifyAll` we're using a `Lock` with 2 `Condition` objects :
* one when the waiting conditions on global lock acquisition have changed
* one when the waiting conditions on bundle lock acquisition have changed