### PR TITLE
[FELIX-5978] Ensure getClassLoader() is called in a safe way when sec…

### DIFF
--- a/framework/src/main/java/org/apache/felix/framework/Felix.java
+++ b/framework/src/main/java/org/apache/felix/framework/Felix.java
@@ -4023,10 +4023,12 @@ public class Felix extends BundleImpl implements Framework
     {
         // If the class comes from bundle class loader, then return
         // associated bundle if it is from this framework instance.
-        if (clazz.getClassLoader() instanceof BundleReference)
+        ClassLoader classLoader = m_secureAction.getClassLoader(clazz);
+        
+        if (classLoader instanceof BundleReference)
         {
             // Only return the bundle if it is from this framework.
-            BundleReference br = (BundleReference) clazz.getClassLoader();
+            BundleReference br = (BundleReference) classLoader;
             return ((br.getBundle() instanceof BundleImpl)
                 && (((BundleImpl) br.getBundle()).getFramework() == this))
                     ? br.getBundle() : null;

--- a/framework/src/main/java/org/apache/felix/framework/URLHandlers.java
+++ b/framework/src/main/java/org/apache/felix/framework/URLHandlers.java
@@ -685,16 +685,19 @@ class URLHandlers implements URLStreamHandlerFactory, ContentHandlerFactory
         Class[] stack = m_sm.getClassContext();
         // Find the first class that is loaded from a bundle.
         Class targetClass = null;
+        ClassLoader targetClassLoader = null;
         for (int i = 0; i < stack.length; i++)
         {
-            if (stack[i].getClassLoader() != null)
+            ClassLoader classLoader = m_secureAction.getClassLoader(stack[i]);
+			if (classLoader != null)
             {
-                String name = stack[i].getClassLoader().getClass().getName();
+                String name = classLoader.getClass().getName();
                 if (name.startsWith("org.apache.felix.framework.ModuleImpl$ModuleClassLoader")
                     || name.equals("org.apache.felix.framework.searchpolicy.ContentClassLoader")
                     || name.startsWith("org.apache.felix.framework.BundleWiringImpl$BundleClassLoader"))
                 {
                     targetClass = stack[i];
+                    targetClassLoader = classLoader;
                     break;
                 }
             }
@@ -705,7 +708,7 @@ class URLHandlers implements URLStreamHandlerFactory, ContentHandlerFactory
         // the bundle that loaded the class.
         if (targetClass != null)
         {
-            ClassLoader index = targetClass.getClassLoader().getClass().getClassLoader();
+            ClassLoader index = m_secureAction.getClassLoader(targetClassLoader.getClass());
 
             List frameworks = (List) m_classloaderToFrameworkLists.get(index);
 

--- a/framework/src/test/java/org/apache/felix/framework/URLHandlersTest.java
+++ b/framework/src/test/java/org/apache/felix/framework/URLHandlersTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.ContentHandler;
 import java.net.InetAddress;
+import java.net.JarURLConnection;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.URLConnection;
@@ -300,7 +301,9 @@ public class URLHandlersTest extends TestCase
 
             new URL("test" + System.identityHashCode(TestURLHandlersActivator.this) + ":").openConnection();
 
-
+            if (!(getClass().getProtectionDomain().getCodeSource().getLocation().openConnection() instanceof JarURLConnection)) {
+                throw new Exception("Unexpted Code Source");
+            }
 
             try
             {
@@ -349,14 +352,19 @@ public class URLHandlersTest extends TestCase
                 reg.unregister();
             }
 
+            boolean fail;
             try
             {
                 new URL("test" + System.identityHashCode(TestURLHandlersActivator.this) + ":").openConnection();
-                throw new Exception("Unexpected url resolve");
+                fail = true;
             }
             catch (Exception ex)
             {
                 // pass
+                fail = false;
+            }
+            if (fail) {
+                throw new Exception("Unexpected url resolve");
             }
 
             Bundle bundle2 = null;
@@ -376,35 +384,47 @@ public class URLHandlersTest extends TestCase
             }
             if (bundle2 != null)
             {
+                fail = false;
                 try
                 {
                     new URL("test" + System.identityHashCode(bundle2) + ":").openConnection();
-                    throw new Exception("Unexpected url2 resolve");
+                    fail = true;
                 }
                 catch (Exception ex)
                 {
+                }
+                if (fail) {
+                    throw new Exception("Unexpected url resolve");
                 }
                 bundle2.start();
                 new URL("test" + System.identityHashCode(bundle2) + ":").openConnection();
                 bundle2.stop();
+                fail = false;
                 try
                 {
                     new URL("test" + System.identityHashCode(bundle2) + ":").openConnection();
-                    throw new Exception("Unexpected url2 resolve");
+                    fail = true;
                 }
                 catch (Exception ex)
                 {
+                }
+                if (fail) {
+                    throw new Exception("Unexpected url resolve");
                 }
             }
             else
             {
+                fail = false;
                 try
                 {
                     new URL("test" + System.identityHashCode(context.getBundle()) + ":").openConnection();
-                    throw new Exception("Unexpected url2 resolve");
+                    fail = true;
                 }
                 catch (Exception ex)
                 {
+                }
+                if (fail) {
+                    throw new Exception("Unexpected url2 resolve");
                 }
                 props = new Hashtable();
                 props.put(URLConstants.URL_HANDLER_PROTOCOL, "test" + System.identityHashCode(context.getBundle()));


### PR DESCRIPTION
…urity is enabled

Previously URLHandlers would explode when security was on because it didn't have permission to get the ClassLoader all the way down the stack

Signed-off-by: Tim Ward <timothyjward@apache.org>