### PR TITLE
FELIX-6023 bnd scrplugin preserve sequence of classpath entries.

### DIFF
--- a/tools/org.apache.felix.scr.bnd/src/main/java/org/apache/felix/scrplugin/bnd/SCRDescriptorBndPlugin.java
+++ b/tools/org.apache.felix.scr.bnd/src/main/java/org/apache/felix/scrplugin/bnd/SCRDescriptorBndPlugin.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -299,7 +300,7 @@ public class SCRDescriptorBndPlugin implements AnalyzerPlugin, Plugin {
 	}
 
 	private URL[] getClassPath(Analyzer a) throws Exception {
-		final Set<URL> path = new HashSet<URL>();
+		final Set<URL> path = new LinkedHashSet<URL>();
 		for (final Jar j : a.getClasspath()) {
 			path.add(j.getSource().toURI().toURL());
 		}


### PR DESCRIPTION
Replace the HashSet used for deduping classpath entries with a LinkedHashSet to retain the precedence established by the Analyzer.