### PR TITLE
FELIX-6047 - Delegate timezone and date format properties to Jetty

### DIFF
--- a/healthcheck/docs/felix-health-checks.md
+++ b/healthcheck/docs/felix-health-checks.md
@@ -171,7 +171,7 @@ By default the HC servlet sends the CORS header `Access-Control-Allow-Origin: *`
 
 ### Webconsole plugin
 
-If the `org.apache.felix.hc.webconsole` bundle is active, a webconsole plugin 
+If the `org.apache.felix.healthcheck.webconsoleplugin` bundle is active, a webconsole plugin
 at `/system/console/healthcheck` allows for executing health checks, optionally selected
 based on their tags (positive and negative selection, see the `HealthCheckFilter` mention above).
 

--- a/http/jetty/src/main/java/org/apache/felix/http/jetty/internal/FileRequestLog.java
+++ b/http/jetty/src/main/java/org/apache/felix/http/jetty/internal/FileRequestLog.java
@@ -58,6 +58,12 @@ class FileRequestLog {
         delegate.setLogCookies(config.isRequestLogFileLogCookies());
         delegate.setLogServer(config.isRequestLogFileLogServer());
         delegate.setLogLatency(config.isRequestLogFileLogLatency());
+        if (config.getRequestLogDateFormat() != null) {
+            delegate.setLogDateFormat(config.getRequestLogDateFormat());
+        }
+        if (config.getRequestLogTimeZone() != null) {
+            delegate.setLogTimeZone(config.getRequestLogTimeZone());
+        }
     }
 
     synchronized void start(BundleContext context) throws IOException, IllegalStateException {

--- a/http/jetty/src/main/java/org/apache/felix/http/jetty/internal/JettyConfig.java
+++ b/http/jetty/src/main/java/org/apache/felix/http/jetty/internal/JettyConfig.java
@@ -216,6 +216,12 @@ public final class JettyConfig
     /** Felix specific property to enable request logging request processing time in the request log file*/
     public static final String FELIX_HTTP_REQUEST_LOG_FILE_LOG_LATENCY = "org.apache.felix.http.requestlog.file.loglatency";
 
+    /** Felix specific property to specify the date format used for the logging timestamps*/
+    public static final String FELIX_HTTP_REQUEST_LOG_FILE_DATE_FORMAT = "org.apache.felix.http.requestlog.file.logdateformat";
+
+    /** Felix specific property to specify the timezone used for the logging timestamps*/
+    public static final String FELIX_HTTP_REQUEST_LOG_FILE_TIMEZONE = "org.apache.felix.http.requestlog.file.timezone";
+
     /** Felix specific property to define custom properties for the http runtime service. */
     public static final String FELIX_CUSTOM_HTTP_RUNTIME_PROPERTY_PREFIX = "org.apache.felix.http.runtime.init.";
 
@@ -580,6 +586,14 @@ public final class JettyConfig
 
     public boolean isRequestLogFileLogLatency() {
         return getBooleanProperty(FELIX_HTTP_REQUEST_LOG_FILE_LOG_LATENCY, false);
+    }
+
+    public String getRequestLogDateFormat() {
+        return getProperty(FELIX_HTTP_REQUEST_LOG_FILE_DATE_FORMAT, null);
+    }
+
+    public String getRequestLogTimeZone() {
+        return getProperty(FELIX_HTTP_REQUEST_LOG_FILE_TIMEZONE, null);
     }
 
 


### PR DESCRIPTION
When using Felix-Jetty we need to be able to configure the timezone and date format used in the request logging. This Pull request enables these options.