### PR TITLE
FELIX-6043 ClassNotFoundException caused by org.osgi.util.function.Function

### DIFF
--- a/scr/pom.xml
+++ b/scr/pom.xml
@@ -118,6 +118,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.util.function</artifactId>
+            <version>1.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.gogo.runtime</artifactId>
             <version>1.0.0</version>


### PR DESCRIPTION
The manifest declares org.osgi.util.function as exported but it is not embedded.
A quick fix is to declare the dependency with maven (see patch)
