### PR TITLE
FELIX-6051: Added PojoServiceRegistry.registerBundle method

### DIFF
--- a/connect/src/main/java/org/apache/felix/connect/launch/PojoServiceRegistry.java
+++ b/connect/src/main/java/org/apache/felix/connect/launch/PojoServiceRegistry.java
@@ -20,7 +20,9 @@ package org.apache.felix.connect.launch;
 
 import java.util.Collection;
 import java.util.Dictionary;
+import java.util.List;
 
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceListener;
@@ -32,6 +34,8 @@ public interface PojoServiceRegistry
     public BundleContext getBundleContext();
 
     public void startBundles(Collection<BundleDescriptor> bundles) throws Exception;
+
+    public Bundle registerBundle(BundleDescriptor bundle) throws Exception;
 
     public void addServiceListener(ServiceListener listener, String filter) throws InvalidSyntaxException;
 

--- a/connect/src/main/java/org/apache/felix/connect/launch/PojoServiceRegistryFactory.java
+++ b/connect/src/main/java/org/apache/felix/connect/launch/PojoServiceRegistryFactory.java
@@ -25,5 +25,8 @@ public interface PojoServiceRegistryFactory
     public static final String BUNDLE_DESCRIPTORS =
             PojoServiceRegistry.class.getName().toLowerCase() + ".bundles";
 
+    public static final String BUNDLES_AUTOSTART =
+            PojoServiceRegistry.class.getName().toLowerCase() + ".bundles.autostart";
+
     public PojoServiceRegistry newPojoServiceRegistry(Map<String, Object> configuration) throws Exception;
 }


### PR DESCRIPTION
Added support to not automatically start scanned bundles. That way, one can selectively start (and stop) bundles.

I also added a new config value to disable auto-starting all bundles when using the Factory with auto-scanning.

This fixes https://issues.apache.org/jira/browse/FELIX-6051