### PR TITLE
Update SCR dependencies to R7

### DIFF
--- a/scr/pom.xml
+++ b/scr/pom.xml
@@ -72,13 +72,13 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.core</artifactId>
-            <version>6.0.0</version>
+            <version>7.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.annotation</artifactId>
-            <version>6.0.1</version>
+            <version>7.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -96,13 +96,13 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.log</artifactId>
-            <version>1.3.0</version>
+            <version>1.4.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.metatype</artifactId>
-            <version>1.3.0</version>
+            <version>1.4.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -114,13 +114,13 @@
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.util.promise</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.gogo.runtime</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -368,7 +368,7 @@
                 <dependency>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>org.apache.felix.framework</artifactId>
-                    <version>4.6.0</version>
+                    <version>6.0.2</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/scr/src/test/java/org/apache/felix/scr/integration/ComponentTestBase.java
+++ b/scr/src/test/java/org/apache/felix/scr/integration/ComponentTestBase.java
@@ -82,6 +82,7 @@ import org.osgi.service.component.runtime.ServiceComponentRuntime;
 import org.osgi.service.component.runtime.dto.ComponentConfigurationDTO;
 import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
 import org.osgi.service.log.LogService;
+import org.osgi.service.log.Logger;
 import org.osgi.util.tracker.ServiceTracker;
 
 import junit.framework.Assert;
@@ -1036,6 +1037,11 @@ public abstract class ComponentTestBase
             {
                 log( level, msg, exception );
             }
+        }
+
+        @Override
+        public <L extends Logger> L getLogger(String name, Class<L> loggerType) {
+            return null;
         }
 
         private int getEnabledLogLevel()


### PR DESCRIPTION
SCR export some OSGi packages (org.osgi.util.promise and uses org.osgi.util.function).

So we should update them to the latest release.