### PR TITLE
FELIX-6095 Fixinig felix connect cannot resolve bundle resources

### DIFF
--- a/connect/src/main/java/org/apache/felix/connect/PojoSRBundle.java
+++ b/connect/src/main/java/org/apache/felix/connect/PojoSRBundle.java
@@ -266,9 +266,21 @@ class PojoSRBundle implements Bundle, BundleRevisions
     @Override
     public URL getResource(String name)
     {
-        // TODO: module - implement this based on the revision
-        URL result = m_classLoader.getResource(name);
-        return result;
+        try
+        {
+            // We need to take resource from JAR bundle instead of classloader, as classloader is shared
+            URL result = new URL(getLocation() + name);
+            if (result.openConnection().getContent() != null) // Checking if requested resource really exists
+            {
+                return result;
+            }
+        }
+        catch (IOException e)
+        {
+            //no-op as requested resource does not exists
+        }
+        return null;
+
     }
 
     @Override


### PR DESCRIPTION
Fixes: https://issues.apache.org/jira/browse/FELIX-6095

The bug occurs because originally PojoSRBundle was trying to take resources from bundle's classloader.
While it would work in OSGi environment where classloader is per bundle, in Felix connect it has no chance to work correctly as classloader is shared.
Therefore getting resources like MATA-INF/spring.handlers for example, picks up the last one "overridden" within classloader, instead of the right one from the right bundle.

Change tested on Camel Test Blueprint project.