### PR TITLE
Fixes #FELIX-6096 SCR fails if the Java Runtime Environment does not …

### DIFF
--- a/scr/src/main/java/org/apache/felix/scr/impl/manager/RegionConfigurationSupport.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/manager/RegionConfigurationSupport.java
@@ -636,8 +636,15 @@ public abstract class RegionConfigurationSupport
         else if ( configBundleLocation.startsWith( "?" ) )
         {
             //multilocation
-            result = bundle.hasPermission(
-                new ConfigurationPermission( configBundleLocation, ConfigurationPermission.TARGET ) );
+            if ( System.getSecurityManager() != null )
+            {
+                result = bundle.hasPermission(
+                        new ConfigurationPermission(configBundleLocation, ConfigurationPermission.TARGET));
+            }
+            else
+            {
+                result = true;
+            }
         }
         else
         {


### PR DESCRIPTION
…support permissions.

Signed-off-by: Christoph Fiehe <christoph.fiehe@materna.de>