### PR TITLE
FELIX-6179 - Fix Jetty Client Authentication

### DIFF
--- a/http/jetty/src/main/java/org/apache/felix/http/jetty/internal/JettyService.java
+++ b/http/jetty/src/main/java/org/apache/felix/http/jetty/internal/JettyService.java
@@ -447,7 +447,7 @@ public final class JettyService extends AbstractLifeCycle.AbstractLifeCycleListe
         HttpConnectionFactory connFactory = new HttpConnectionFactory();
         configureHttpConnectionFactory(connFactory);
 
-        SslContextFactory sslContextFactory = new SslContextFactory();
+        SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
         configureSslContextFactory(sslContextFactory);
 
         ServerConnector connector = new ServerConnector(
@@ -470,7 +470,7 @@ public final class JettyService extends AbstractLifeCycle.AbstractLifeCycleListe
         return startConnector(connector);
     }
 
-    private void configureSslContextFactory(final SslContextFactory connector)
+    private void configureSslContextFactory(final SslContextFactory.Server connector)
     {
         if (this.config.getKeystoreType() != null)
         {


### PR DESCRIPTION
Jetty Client authentication does not work, see: https://github.com/eclipse/jetty.project/issues/3554. Changing to use SslContextFactory.Server as in the patch fixes this issue.