### PR TITLE
FELIX-6182: Added jetty stop timeout property

### DIFF
--- a/http/jetty/src/main/java/org/apache/felix/http/jetty/internal/JettyConfig.java
+++ b/http/jetty/src/main/java/org/apache/felix/http/jetty/internal/JettyConfig.java
@@ -263,6 +263,9 @@ public final class JettyConfig
 
     /** Felix specific property to specify the excluded mime types. */
     public static final String FELIX_JETTY_GZIP_EXCLUDED_MIME_TYPES = "org.apache.felix.jetty.gzip.excludedMimeTypes";
+    
+    /** Felix specific property to specify the stop timeout of the jetty server */
+    public static final String FELIX_JETTY_STOP_TIMEOUT = "org.apache.felix.jetty.stopTimeout";
 
     private static String validateContextPath(String ctxPath)
     {
@@ -659,6 +662,10 @@ public final class JettyConfig
 
     public String[] getGzipExcludedMimeTypes() {
         return getStringArrayProperty(FELIX_JETTY_GZIP_EXCLUDED_MIME_TYPES, new String[0]);
+    }
+
+    public long getStopTimeout() {
+        return getLongProperty(FELIX_JETTY_STOP_TIMEOUT, -1l);
     }
 
     public void reset()

--- a/http/jetty/src/main/java/org/apache/felix/http/jetty/internal/JettyService.java
+++ b/http/jetty/src/main/java/org/apache/felix/http/jetty/internal/JettyService.java
@@ -321,6 +321,11 @@ public final class JettyService extends AbstractLifeCycle.AbstractLifeCycleListe
 
             	this.server.insertHandler(gzipHandler);
             }
+            
+            if(this.config.getStopTimeout() != -1)
+            {
+              this.server.setStopTimeout(this.config.getStopTimeout());
+            }
 
             this.server.start();
 


### PR DESCRIPTION
Added a additional osgi property in JettyConfig to make the stop timeout of jetty configurable (see https://issues.apache.org/jira/browse/FELIX-6182)