### PR TITLE
FELIX-6189 - Make sure jar/zip files are jailed to the destination di…

### DIFF
--- a/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/FileUtil.java
+++ b/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/FileUtil.java
@@ -112,6 +112,9 @@ public class FileUtil
             }
 
             File target = new File(dir, je.getName());
+            if (!target.getCanonicalPath().startsWith(dir.getCanonicalPath())) {
+                throw new IOException("The output file is not contained in the destination directory");
+            }
 
             // Check to see if the JAR entry is a directory.
             if (je.isDirectory())

--- a/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/ObrGogoCommand.java
+++ b/bundlerepository/src/main/java/org/apache/felix/bundlerepository/impl/ObrGogoCommand.java
@@ -765,6 +765,9 @@ public class ObrGogoCommand
             }
 
             File target = new File(dir, je.getName());
+            if (!target.getCanonicalPath().startsWith(dir.getCanonicalPath())) {
+                throw new IOException("The output file is not contained in the destination directory");
+            }
 
             // Check to see if the JAR entry is a directory.
             if (je.isDirectory())

--- a/deploymentadmin/deploymentadmin/src/main/java/org/apache/felix/deploymentadmin/spi/SnapshotCommand.java
+++ b/deploymentadmin/deploymentadmin/src/main/java/org/apache/felix/deploymentadmin/spi/SnapshotCommand.java
@@ -92,6 +92,9 @@ public class SnapshotCommand extends Command {
             ZipEntry entry;
             while ((entry = input.getNextEntry()) != null) {
                 File targetEntry = new File(targetDir, entry.getName());
+                if (!targetEntry.getCanonicalPath().startsWith(targetDir.getCanonicalPath())) {
+                    throw new IOException("The output file is not contained in the destination directory");
+                }
 
                 if (entry.isDirectory()) {
                     if (!targetEntry.mkdirs()) {

--- a/gogo/command/src/main/java/org/apache/felix/gogo/command/Util.java
+++ b/gogo/command/src/main/java/org/apache/felix/gogo/command/Util.java
@@ -166,6 +166,9 @@ public class Util
             }
 
             File target = new File(dir, je.getName());
+            if (!target.getCanonicalPath().startsWith(dir.getCanonicalPath())) {
+                throw new IOException("The output file is not contained in the destination directory");
+            }
 
             // Check to see if the JAR entry is a directory.
             if (je.isDirectory())


### PR DESCRIPTION
…rectory

There are a number of locations in Felix where we unzip a jar or zip file to the filesystem, without checking that the all of the files are jailed to the intended destination directory. This is a potential security issue as it allows an attacked to overwrite files on the system outside of the intended directory.