### PR TITLE
FELIX-6193 - Update maven-archiver + plexus-utils

### DIFF
--- a/tools/maven-bundle-plugin/pom.xml
+++ b/tools/maven-bundle-plugin/pom.xml
@@ -207,7 +207,7 @@
   <dependency>
    <groupId>org.apache.maven</groupId>
    <artifactId>maven-archiver</artifactId>
-   <version>2.6</version>
+   <version>3.4.0</version>
   </dependency>
   <dependency>
    <groupId>org.apache.maven.shared</groupId>

--- a/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/BundlePlugin.java
+++ b/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/BundlePlugin.java
@@ -1070,7 +1070,7 @@ public class BundlePlugin extends AbstractMojo
              * Grab customized manifest entries from the maven-jar-plugin configuration
              */
             MavenArchiveConfiguration archiveConfig = JarPluginConfiguration.getArchiveConfiguration( currentProject );
-            String mavenManifestText = new MavenArchiver().getManifest( currentProject, archiveConfig ).toString();
+            String mavenManifestText = new MavenArchiver().getManifest( currentProject, archiveConfig.getManifest() ).toString();
             addMavenDescriptor = addMavenDescriptor && archiveConfig.isAddMavenDescriptor();
 
             Manifest mavenManifest = new Manifest();


### PR DESCRIPTION


We should update the versions of maven-archiver + plexus-utils in the maven-bundle-plugin to remove the CVEs:

plexus-archiver-2.8.1.jar (pkg:maven/org.codehaus.plexus/plexus-archiver@2.8.1, cpe:2.3:a:plexus-archiver_project:plexus-archiver:2.8.1:::::::*) : CVE-2018-1002200
plexus-utils-3.0.10.jar (pkg:maven/org.codehaus.plexus/plexus-utils@3.0.10, cpe:2.3:a:plexus-utils_project:plexus-utils:3.0.10:::::::*) : CVE-2017-1000487, Directory traversal in org.codehaus.plexus.util.Expand, Possible XML Injection
