### PR TITLE
[FELIX-6203] [maven-release-plugin] Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/BundlePlugin.java
+++ b/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/BundlePlugin.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1564,6 +1565,19 @@ public class BundlePlugin extends AbstractMojo
     }
 
 
+    private static Date getReproducibleBuildDate() {
+        String envVariable = System.getenv("SOURCE_DATE_EPOCH");
+        if (envVariable == null) {
+            return null;
+        }
+        try {
+            return new Date(Long.parseLong(envVariable)*1000);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+
     /**
      * @param jar
      * @throws IOException
@@ -1582,7 +1596,8 @@ public class BundlePlugin extends AbstractMojo
             jar.putResource( path + "/pom.xml", new FileResource( pomFile ) );
         }
 
-        Properties p = new Properties();
+        java.util.Date buildDate = getReproducibleBuildDate();
+        Properties p = buildDate == null ? new Properties() : new TimestampedProperties(buildDate);
         p.put( "version", currentProject.getVersion() );
         p.put( "groupId", currentProject.getGroupId() );
         p.put( "artifactId", currentProject.getArtifactId() );

--- a/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/TimestampedProperties.java
+++ b/tools/maven-bundle-plugin/src/main/java/org/apache/felix/bundleplugin/TimestampedProperties.java
@@ -1,0 +1,48 @@
+package org.apache.felix.bundleplugin;
+
+import java.io.*;
+import java.text.*;
+import java.util.*;
+import java.util.regex.*;
+
+/**
+ * Properties file timestamped with a specified date.
+ */
+class TimestampedProperties extends Properties
+{
+    private Date date;
+
+    public TimestampedProperties(Date date) {
+        this.date = date;
+    }
+
+    @Override
+    public void store(OutputStream out, String comments) throws IOException {
+        store(new OutputStreamWriter(out, "ISO-8859-1"), comments);
+    }
+
+    @Override
+    public void store(Writer out, String comments) throws IOException {
+        // store the properties file in memory
+        StringWriter buffer = new StringWriter();
+        super.store(buffer, comments);
+
+        // Replace the date on the second line of the file
+        SimpleDateFormat fmt = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH);
+        fmt.setTimeZone(TimeZone.getTimeZone("UTC"));
+        String[] lines = buffer.toString().split(Pattern.quote(System.getProperty("line.separator")));
+        lines[1] = "#" + fmt.format(date);
+
+        // write the file
+        BufferedWriter writer = new BufferedWriter(out);
+        try {
+            for (String line : lines) {
+                writer.write(line);
+                writer.newLine();
+            }
+            writer.flush();
+        } finally {
+            writer.close();
+        }
+    }
+}


### PR DESCRIPTION
For https://issues.apache.org/jira/projects/FELIX/issues/FELIX-6203

Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This patch is based on https://salsa.debian.org/java-team/maven-bundle-plugin/blob/master/debian/patches/use-changelog-date-as-pom.properties-timestamp.patch
by `Emmanuel Bourg <ebourg apache.org>`

This PR was done while working on reproducible builds for openSUSE.