### PR TITLE
FELIX-6202: ignore component name reservations in ComponentRegistry.getComponentHolders()

### DIFF
--- a/scr/src/main/java/org/apache/felix/scr/impl/ComponentRegistry.java
+++ b/scr/src/main/java/org/apache/felix/scr/impl/ComponentRegistry.java
@@ -346,7 +346,14 @@ public class ComponentRegistry
     	List<ComponentHolder<?>> all = new ArrayList<>();
         synchronized ( m_componentHoldersByName )
         {
-        	all.addAll(m_componentHoldersByName.values());
+            for (ComponentHolder<?> holder: m_componentHoldersByName.values())
+            {
+                // Ignore name reservations
+                if (holder != null)
+                {
+                    all.add(holder);
+                }
+            }
         }
         return all;
     }


### PR DESCRIPTION
Internal map can contain null values when a name is reserved, leading to undocumented null entries in the return list. Callers are not equipped to handle this implementation detail, hence filter null values from the returned list.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>