### PR TITLE
FELIX-6215 - Cannot run scr unit tests on Java 11

### DIFF
--- a/scr/pom.xml
+++ b/scr/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.17.0</version>
+            <version>2.28.2</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Updates to the latest version of mockito 2.x for Java 11 support

Signed-off-by: Mat Booth <mat.booth@redhat.com>